### PR TITLE
Remove bundle prefix from constant value before comparing to constant name

### DIFF
--- a/src/Shared/ModuleConstantsNoMethodAllowedRule.php
+++ b/src/Shared/ModuleConstantsNoMethodAllowedRule.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace ArchitectureSniffer\Shared;
+
+use PHPMD\AbstractNode;
+use PHPMD\AbstractRule;
+use PHPMD\Rule\InterfaceAware;
+
+class ModuleConstantsNoMethodAllowedRule extends AbstractRule implements InterfaceAware
+{
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return 'The modules\' *ConstantsInterface interfaces must only contain constants to be used with env config.';
+    }
+
+    /**
+     * @param \PHPMD\AbstractNode $node
+     *
+     * @return void
+     */
+    public function apply(AbstractNode $node)
+    {
+        if (0 === preg_match('([A-Za-z0-9]+Constants$)', $node->getName())) {
+            return;
+        }
+
+        foreach ($node->getMethods() as $method) {
+            $this->addViolation(
+                $node,
+                [
+                    sprintf(
+                        'Interface %s defines a method %s() which violates rule "Just constants in these interfaces"',
+                        $node->getFullQualifiedName(),
+                        $method->getName()
+                    )
+                ]
+            );
+        }
+    }
+
+}

--- a/src/Shared/ModuleConstantsRule.php
+++ b/src/Shared/ModuleConstantsRule.php
@@ -43,6 +43,8 @@ class ModuleConstantsRule extends AbstractRule implements InterfaceAware
 
         foreach ($node->findChildrenOfType('ConstantDeclarator') as $constant) {
             $value = $constant->getValue()->getValue();
+            $value = $this->trimBundleNamePrefix($value);
+
             if ($constant->getImage() === $value) {
                 continue;
             }
@@ -63,6 +65,20 @@ class ModuleConstantsRule extends AbstractRule implements InterfaceAware
                 ]
             );
         }
+    }
+
+    /**
+     * @param mixed $constantValue
+     *
+     * @return mixed
+     */
+    private function trimBundleNamePrefix($constantValue)
+    {
+        if (!is_string($constantValue)) {
+            return $constantValue;
+        }
+
+        return preg_replace('/[A-Z0-9_]+:/', '', $constantValue);
     }
 
 }

--- a/src/Shared/ModuleConstantsRule.php
+++ b/src/Shared/ModuleConstantsRule.php
@@ -57,7 +57,7 @@ class ModuleConstantsRule extends AbstractRule implements InterfaceAware
                 $node,
                 [
                     sprintf(
-                        'The value "%s" and the name of constant %s::%s are not equal which violates rule "Only keys no values"',
+                        'The value "%s" and the name of constant %s::%s are not equal which violates rule "Only keys no values" (a prefix separated with ":" is allowed for the value)',
                         $value,
                         $node->getFullQualifiedName(),
                         $constant->getImage()
@@ -78,7 +78,7 @@ class ModuleConstantsRule extends AbstractRule implements InterfaceAware
             return $constantValue;
         }
 
-        return preg_replace('/[A-Z0-9_]+:/', '', $constantValue);
+        return preg_replace('/^[A-Z0-9_]+:/', '', $constantValue);
     }
 
 }

--- a/src/Shared/ModuleConstantsRule.php
+++ b/src/Shared/ModuleConstantsRule.php
@@ -14,7 +14,7 @@ class ModuleConstantsRule extends AbstractRule implements InterfaceAware
      */
     public function getDescription()
     {
-        return 'The modules\' *ConstantsInterface interfaces must only contain constants to be used with env config. They also must be prefix with the module name.';
+        return 'The modules\' *Constants interfaces must only contain constants to be used with env config. They also must be prefixed with the module name.';
     }
 
     /**
@@ -28,57 +28,21 @@ class ModuleConstantsRule extends AbstractRule implements InterfaceAware
             return;
         }
 
-        foreach ($node->getMethods() as $method) {
-            $this->addViolation(
-                $node,
-                [
-                    sprintf(
-                        'Interface %s defines a method %s() which violates rule "Just constants in these interfaces"',
-                        $node->getFullQualifiedName(),
-                        $method->getName()
-                    )
-                ]
-            );
-        }
+        $moduleName = str_replace('Constants', '', $node->getName());
 
         foreach ($node->findChildrenOfType('ConstantDeclarator') as $constant) {
             $value = $constant->getValue()->getValue();
-            $value = $this->trimBundleNamePrefix($value);
 
-            if ($constant->getImage() === $value) {
-                continue;
+            $expectedConstantValue = strtoupper($moduleName) . ':' . $constant->getImage();
+            if ($expectedConstantValue !== $value) {
+                $message = sprintf(
+                    'The constant value is expected to be "%s" but is "%s". This violates the rule "Constant values must be exactly the same as the const key prefixed with module name"',
+                    $expectedConstantValue,
+                    $value
+                );
+                $this->addViolation($node, [$message]);
             }
-
-            if (is_array($value)) {
-                $value = preg_replace(['([\n\r\s]+)', '( ([\(\)]))'], [' ', '\\1'], var_export($value, true));
-            }
-
-            $this->addViolation(
-                $node,
-                [
-                    sprintf(
-                        'The value "%s" and the name of constant %s::%s are not equal which violates rule "Only keys no values" (a prefix separated with ":" is allowed for the value)',
-                        $value,
-                        $node->getFullQualifiedName(),
-                        $constant->getImage()
-                    )
-                ]
-            );
         }
-    }
-
-    /**
-     * @param mixed $constantValue
-     *
-     * @return mixed
-     */
-    private function trimBundleNamePrefix($constantValue)
-    {
-        if (!is_string($constantValue)) {
-            return $constantValue;
-        }
-
-        return preg_replace('/^[A-Z0-9_]+:/', '', $constantValue);
     }
 
 }

--- a/src/Shared/ruleset.xml
+++ b/src/Shared/ruleset.xml
@@ -18,4 +18,12 @@
         <priority>5</priority>
     </rule>
 
+    <rule
+        name="ModuleConstantsNoMethodAllowedRule"
+        message="Shared Module Constants: {0}"
+        class="ArchitectureSniffer\Shared\ModuleConstantsNoMethodAllowedRule">
+
+        <priority>3</priority>
+    </rule>
+
 </ruleset>


### PR DESCRIPTION
With CORE-984 (https://github.com/spryker/spryker/pull/2507) we introduce config constants that are scoped to bundles by adding the bundle name as a prefix to the constant's value (e.g. `const BASE_URL_YVES = 'NEWSLETTER:BASE_URL_YVES'`)