### PR TITLE
Added Architecture rules for method names in DependencyProvider

### DIFF
--- a/src/Client/DependencyProvider/DependencyProviderMethodNameRule.php
+++ b/src/Client/DependencyProvider/DependencyProviderMethodNameRule.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace ArchitectureSniffer\Client\DependencyProvider;
+
+use ArchitectureSniffer\Common\DependencyProvider\AbstractDependencyProviderRule;
+use PHPMD\AbstractNode;
+use PHPMD\Rule\MethodAware;
+
+class DependencyProviderMethodNameRule extends AbstractDependencyProviderRule implements MethodAware
+{
+
+    /**
+     * @var array
+     */
+    protected $allowedProvideMethodNames = [
+        'provideServiceLayerDependencies',
+    ];
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return static::RULE;
+    }
+
+    /**
+     * @param \PHPMD\AbstractNode $node
+     *
+     * @return void
+     */
+    public function apply(AbstractNode $node)
+    {
+        if (!$this->isDependencyProvider($node, 'Client')) {
+            return;
+        }
+
+        $this->applyRule($node, $this->allowedProvideMethodNames);
+    }
+
+}

--- a/src/Client/ruleset.xml
+++ b/src/Client/ruleset.xml
@@ -18,4 +18,12 @@
         <priority>1</priority>
     </rule>
 
+    <rule
+        name="ClientDependencyProviderMethodNameRule"
+        message="DependencyProvider: {0}"
+        class="ArchitectureSniffer\Client\DependencyProvider\DependencyProviderMethodNameRule">
+
+        <priority>3</priority>
+    </rule>
+
 </ruleset>

--- a/src/Common/DependencyProvider/AbstractDependencyProviderRule.php
+++ b/src/Common/DependencyProvider/AbstractDependencyProviderRule.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace ArchitectureSniffer\Common\DependencyProvider;
+
+use PHPMD\AbstractRule;
+use PHPMD\Node\AbstractNode;
+use PHPMD\Node\MethodNode;
+
+abstract class AbstractDependencyProviderRule extends AbstractRule
+{
+
+    const RULE = 'DependencyProvider should only contain additional add*() or get*() methods.';
+
+    /**
+     * @param \PHPMD\Node\AbstractNode $node
+     * @param string $application
+     *
+     * @return bool
+     */
+    protected function isDependencyProvider(AbstractNode $node, $application)
+    {
+        $className = $node->getFullQualifiedName();
+        if ($node instanceof MethodNode) {
+            $parent = $node->getNode()->getParent();
+            $className = $parent->getNamespaceName() . '\\' . $parent->getName();
+        }
+
+        if (preg_match('/\\\\' . $application . '\\\\.*\\\\.*DependencyProvider$/', $className)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param \PHPMD\Node\MethodNode $method
+     * @param array $allowedProvideMethodNames
+     *
+     * @return void
+     */
+    protected function applyRule(MethodNode $method, array $allowedProvideMethodNames)
+    {
+        if (in_array($method->getName(), $allowedProvideMethodNames)) {
+            return;
+        }
+
+        if (0 != preg_match('/^(add|get).+/', $method->getName())) {
+            return;
+        }
+
+        $message = sprintf(
+            'The DependencyProvider method %s() violates rule "%s"',
+            $method->getName(),
+            static::RULE
+        );
+
+        $this->addViolation($method, [$message]);
+    }
+
+}

--- a/src/Common/DependencyProvider/AbstractDependencyProviderRule.php
+++ b/src/Common/DependencyProvider/AbstractDependencyProviderRule.php
@@ -2,12 +2,15 @@
 
 namespace ArchitectureSniffer\Common\DependencyProvider;
 
+use ArchitectureSniffer\Common\DeprecationTrait;
 use PHPMD\AbstractRule;
 use PHPMD\Node\AbstractNode;
 use PHPMD\Node\MethodNode;
 
 abstract class AbstractDependencyProviderRule extends AbstractRule
 {
+
+    use DeprecationTrait;
 
     const RULE = 'DependencyProvider should only contain additional add*() or get*() methods.';
 
@@ -40,6 +43,10 @@ abstract class AbstractDependencyProviderRule extends AbstractRule
      */
     protected function applyRule(MethodNode $method, array $allowedProvideMethodNames)
     {
+        if ($this->isMethodDeprecated($method)) {
+            return;
+        }
+
         if (in_array($method->getName(), $allowedProvideMethodNames)) {
             return;
         }

--- a/src/Common/DeprecationTrait.php
+++ b/src/Common/DeprecationTrait.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Copyright © 2017-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace ArchitectureSniffer\Common;
+
+use PHPMD\Node\MethodNode;
+
+trait DeprecationTrait
+{
+
+    /**
+     * @var string
+     */
+    protected $regexp = '(@([a-z_][a-z0-9_]+))i';
+
+    /**
+     * @param \PHPMD\Node\MethodNode $method
+     *
+     * @return bool
+     */
+    protected function isMethodDeprecated(MethodNode $method)
+    {
+        preg_match_all($this->regexp, $method->getNode()->getDocComment(), $matches);
+        foreach (array_keys($matches[0]) as $i) {
+            if ($matches[1][$i] === 'deprecated') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Common/DeprecationTrait.php
+++ b/src/Common/DeprecationTrait.php
@@ -15,7 +15,7 @@ trait DeprecationTrait
     /**
      * @var string
      */
-    protected $regexp = '(@([a-z_][a-z0-9_]+))i';
+    protected $regexp = '/@deprecated/i';
 
     /**
      * @param \PHPMD\Node\MethodNode $method
@@ -24,13 +24,7 @@ trait DeprecationTrait
      */
     protected function isMethodDeprecated(MethodNode $method)
     {
-        preg_match_all($this->regexp, $method->getNode()->getDocComment(), $matches);
-        foreach (array_keys($matches[0]) as $i) {
-            if ($matches[1][$i] === 'deprecated') {
-                return true;
-            }
-        }
-
-        return false;
+        return preg_match($this->regexp, $method->getNode()->getDocComment());
     }
+
 }

--- a/src/Common/DeprecationTrait.php
+++ b/src/Common/DeprecationTrait.php
@@ -24,7 +24,7 @@ trait DeprecationTrait
      */
     protected function isMethodDeprecated(MethodNode $method)
     {
-        return preg_match($this->regexp, $method->getNode()->getDocComment());
+        return (bool)preg_match($this->regexp, $method->getNode()->getDocComment());
     }
 
 }

--- a/src/Service/DependencyProvider/DependencyProviderMethodNameRule.php
+++ b/src/Service/DependencyProvider/DependencyProviderMethodNameRule.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace ArchitectureSniffer\Service\DependencyProvider;
+
+use ArchitectureSniffer\Common\DependencyProvider\AbstractDependencyProviderRule;
+use PHPMD\AbstractNode;
+use PHPMD\Rule\MethodAware;
+
+class DependencyProviderMethodNameRule extends AbstractDependencyProviderRule implements MethodAware
+{
+
+    /**
+     * @var array
+     */
+    protected $allowedProvideMethodNames = [
+        'provideServiceDependencies',
+    ];
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return static::RULE;
+    }
+
+    /**
+     * @param \PHPMD\AbstractNode $node
+     *
+     * @return void
+     */
+    public function apply(AbstractNode $node)
+    {
+        if (!$this->isDependencyProvider($node, 'Service')) {
+            return;
+        }
+
+        $this->applyRule($node, $this->allowedProvideMethodNames);
+    }
+
+}

--- a/src/Service/ruleset.xml
+++ b/src/Service/ruleset.xml
@@ -16,4 +16,12 @@
         <priority>1</priority>
     </rule>
 
+    <rule
+        name="ServiceDependencyProviderMethodNameRule"
+        message="DependencyProvider: {0}"
+        class="ArchitectureSniffer\Service\DependencyProvider\DependencyProviderMethodNameRule">
+
+        <priority>3</priority>
+    </rule>
+
 </ruleset>

--- a/src/Yves/DependencyProvider/DependencyProviderMethodNameRule.php
+++ b/src/Yves/DependencyProvider/DependencyProviderMethodNameRule.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace ArchitectureSniffer\Yves\DependencyProvider;
+
+use ArchitectureSniffer\Common\DependencyProvider\AbstractDependencyProviderRule;
+use PHPMD\AbstractNode;
+use PHPMD\Rule\MethodAware;
+
+class DependencyProviderMethodNameRule extends AbstractDependencyProviderRule implements MethodAware
+{
+
+    /**
+     * @var array
+     */
+    protected $allowedProvideMethodNames = [
+        'provideDependencies',
+    ];
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return static::RULE;
+    }
+
+    /**
+     * @param \PHPMD\AbstractNode $node
+     *
+     * @return void
+     */
+    public function apply(AbstractNode $node)
+    {
+        if (!$this->isDependencyProvider($node, 'Yves')) {
+            return;
+        }
+
+        $this->applyRule($node, $this->allowedProvideMethodNames);
+    }
+
+}

--- a/src/Yves/ruleset.xml
+++ b/src/Yves/ruleset.xml
@@ -10,4 +10,11 @@
         Asserting clean code architecture with Spryker framework.
     </description>
 
+    <rule
+            name="YvesDependencyProviderMethodNameRule"
+            message="DependencyProvider: {0}"
+            class="ArchitectureSniffer\Yves\DependencyProvider\DependencyProviderMethodNameRule">
+
+        <priority>3</priority>
+    </rule>
 </ruleset>

--- a/src/Zed/DependencyProvider/DependencyProviderMethodNameRule.php
+++ b/src/Zed/DependencyProvider/DependencyProviderMethodNameRule.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace ArchitectureSniffer\Zed\DependencyProvider;
+
+use ArchitectureSniffer\Common\DependencyProvider\AbstractDependencyProviderRule;
+use PHPMD\AbstractNode;
+use PHPMD\Rule\MethodAware;
+
+class DependencyProviderMethodNameRule extends AbstractDependencyProviderRule implements MethodAware
+{
+
+    /**
+     * @var array
+     */
+    protected $allowedProvideMethodNames = [
+        'provideCommunicationLayerDependencies',
+        'provideBusinessLayerDependencies',
+        'providePersistenceLayerDependencies',
+    ];
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return static::RULE;
+    }
+
+    /**
+     * @param \PHPMD\AbstractNode $node
+     *
+     * @return void
+     */
+    public function apply(AbstractNode $node)
+    {
+        if (!$this->isDependencyProvider($node, 'Zed')) {
+            return;
+        }
+
+        $this->applyRule($node, $this->allowedProvideMethodNames);
+    }
+
+}

--- a/src/Zed/ruleset.xml
+++ b/src/Zed/ruleset.xml
@@ -91,4 +91,12 @@
         <priority>3</priority>
     </rule>
 
+    <rule
+        name="ZedDependencyProviderMethodNameRule"
+        message="Zed DependencyProvider - DependencyProvider: {0}"
+        class="ArchitectureSniffer\Zed\DependencyProvider\DependencyProviderMethodNameRule">
+
+        <priority>3</priority>
+    </rule>
+
 </ruleset>


### PR DESCRIPTION
Only allow provide*() + add*() or get*() methods in DependencyProvider