### PR TITLE
Use less superoptional wildcard to match more concrete. 

### DIFF
--- a/src/Common/DependencyProvider/AbstractDependencyProviderRule.php
+++ b/src/Common/DependencyProvider/AbstractDependencyProviderRule.php
@@ -27,7 +27,7 @@ abstract class AbstractDependencyProviderRule extends AbstractRule
             $className = $parent->getNamespaceName() . '\\' . $parent->getName();
         }
 
-        if (preg_match('/\\\\' . $application . '\\\\.*\\\\.*DependencyProvider$/', $className)) {
+        if (preg_match('/\\\\' . $application . '\\\\.*\\\\\w+DependencyProvider$/', $className)) {
             return true;
         }
 

--- a/src/Common/Factory/AbstractFactoryRule.php
+++ b/src/Common/Factory/AbstractFactoryRule.php
@@ -8,7 +8,7 @@ use PHPMD\Node\MethodNode;
 
 abstract class AbstractFactoryRule extends SprykerAbstractRule
 {
-    const PATTERN_ZED_FACTORY = '/\\\\*\\\\.*\\\\.*\\\\.*Factory$/';
+    const PATTERN_ZED_FACTORY = '/\\\\\w+\\\\\w+\\\\\w+\\\\.*Factory$/';
 
     /**
      * @param \PHPMD\Node\AbstractNode $node

--- a/src/Zed/Business/Facade/AbstractFacadeRule.php
+++ b/src/Zed/Business/Facade/AbstractFacadeRule.php
@@ -22,7 +22,7 @@ abstract class AbstractFacadeRule extends AbstractRule
             $className = $node->getFullQualifiedName();
         }
 
-        if (preg_match('/\\\\Zed\\\\.*\\\\Business\\\\\w+Facade$/', $className)) {
+        if (preg_match('/\\\\Zed\\\\\w+\\\\Business\\\\\w+Facade$/', $className)) {
             return true;
         }
 

--- a/src/Zed/Business/Facade/FacadeReturnValueRule.php
+++ b/src/Zed/Business/Facade/FacadeReturnValueRule.php
@@ -18,7 +18,7 @@ class FacadeReturnValueRule extends AbstractFacadeRule implements MethodAware
         return static::RULE;
     }
 
-    const ALLOWED_RETURN_TYPES_PATTERN = '/@return\s(?!void|int|float|integer|string|array|\[\]|.*\[\]|bool|boolean|((.*)Transfer))(.*)/';
+    const ALLOWED_RETURN_TYPES_PATTERN = '/@return\s(?!void|int|float|integer|string|array|\[\]|.*\[\]|bool|boolean|((.+)Transfer))(.*)/';
     const INVALID_RETURN_TYPE_MATCH = 3;
 
     /**

--- a/src/Zed/Business/Factory/ZedBusinessFactoryMethodReturnInterfaceRule.php
+++ b/src/Zed/Business/Factory/ZedBusinessFactoryMethodReturnInterfaceRule.php
@@ -11,7 +11,7 @@ class ZedBusinessFactoryMethodReturnInterfaceRule extends AbstractFactoryRule im
 {
     const RULE = 'Every method in a Factory must only return an interface or an array of interfaces.';
 
-    const ALLOWED_RETURN_TYPES_PATTERN = '/@return\s(?!((.*)Interface|callable))(.*)/';
+    const ALLOWED_RETURN_TYPES_PATTERN = '/@return\s+(?!((.+)Interface|callable))(.*)/';
     const INVALID_RETURN_TYPE_MATCH = 3;
 
     /**

--- a/src/Zed/Dependency/Bridge/AbstractBridgeRule.php
+++ b/src/Zed/Dependency/Bridge/AbstractBridgeRule.php
@@ -22,7 +22,7 @@ abstract class AbstractBridgeRule extends AbstractRule
             $className = $node->getFullQualifiedName();
         }
 
-        if (preg_match('/\\\\Dependency\\\\.*\\\\.*Bridge$/', $className)) {
+        if (preg_match('/\\\\Dependency\\\\\w+\\\\\w+Bridge$/', $className)) {
             return true;
         }
 

--- a/src/Zed/Persistence/Factory/AbstractFactoryRule.php
+++ b/src/Zed/Persistence/Factory/AbstractFactoryRule.php
@@ -22,7 +22,7 @@ abstract class AbstractFactoryRule extends AbstractRule
             $className = $node->getFullQualifiedName();
         }
 
-        if (preg_match('/\\\\Zed\\\\.*\\\\Business\\\\.*Factory$/', $className)) {
+        if (preg_match('/\\\\Zed\\\\\w+\\\\Business\\\\\w+Factory$/', $className)) {
             return true;
         }
 


### PR DESCRIPTION
Less false positives.

e.g. fixes
Spryker\Zed\Development\Business\DependencyTree\DependencyFinder\LocatorFacade