### PR TITLE
MISC: allow magic methods in factories

### DIFF
--- a/src/Common/Factory/FactoryOnlyGetAndCreateRule.php
+++ b/src/Common/Factory/FactoryOnlyGetAndCreateRule.php
@@ -8,7 +8,7 @@ use PHPMD\Rule\ClassAware;
 
 class FactoryOnlyGetAndCreateRule extends AbstractFactoryRule implements ClassAware
 {
-    const RULE = 'Factories should only contain magic, get*() and create*() methods.';
+    const RULE = 'Factories should only contain get*() and create*() methods.';
 
     /**
      * @return string

--- a/src/Common/Factory/FactoryOnlyGetAndCreateRule.php
+++ b/src/Common/Factory/FactoryOnlyGetAndCreateRule.php
@@ -8,7 +8,7 @@ use PHPMD\Rule\ClassAware;
 
 class FactoryOnlyGetAndCreateRule extends AbstractFactoryRule implements ClassAware
 {
-    const RULE = 'Factories should only contain get*() and create*() methods.';
+    const RULE = 'Factories should only contain magic, get*() and create*() methods.';
 
     /**
      * @return string
@@ -41,7 +41,7 @@ class FactoryOnlyGetAndCreateRule extends AbstractFactoryRule implements ClassAw
      */
     protected function applyRule(MethodNode $method)
     {
-        if (0 != preg_match('/^(create|get).+/', $method->getName())) {
+        if (0 != preg_match('/^(\_\_|create|get).+/', $method->getName())) {
             return;
         }
 


### PR DESCRIPTION
Idea is to allow magic methods like `__construct` in Factories.
This is used when we split huge factory into smaller ones.

Example: https://github.com/spryker-eco/amazon-pay/blob/master/src/SprykerEco/Zed/Amazonpay/Business/Api/Converter/ConverterFactory.php