### PR TITLE
MISC check this rule only for Shared constants

### DIFF
--- a/src/Shared/ModuleConstantsRule.php
+++ b/src/Shared/ModuleConstantsRule.php
@@ -25,7 +25,8 @@ class ModuleConstantsRule extends AbstractRule implements InterfaceAware
      */
     public function apply(AbstractNode $node)
     {
-        if (preg_match('([A-Za-z0-9]+Constants$)', $node->getName()) === 0) {
+        if (preg_match('([A-Za-z0-9]+Constants$)', $node->getName()) === 0
+            || preg_match("(\\\\Shared\\\\)", $node->getNamespaceName()) === 0) {
             return;
         }
 


### PR DESCRIPTION
Files with constants might appear in any place, especially for payment methods.
Idea is to check this rule only for /Shared/ constants.