### PR TITLE
Business directory should not contain Model sub directory anymore

### DIFF
--- a/.license
+++ b/.license
@@ -1,0 +1,4 @@
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
 
 install:
   - composer self-update && composer --version
-  - composer install --no-interaction --prefer-dist --no-autoloader
+  - composer install --no-interaction --prefer-dist
 
 script:
   - vendor/bin/phpcs -p --extensions=php --standard=vendor/spryker/code-sniffer/Spryker/ruleset.xml src

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
 
 script:
   - vendor/bin/phpcs -p --extensions=php --standard=vendor/spryker/code-sniffer/Spryker/ruleset.xml src
+  - vendor/bin/phpstan analyze src/ -l 1
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 php:
-  - 7.0
+  - 7.1
 
 cache:
   directories:
@@ -13,6 +13,7 @@ install:
 
 script:
   - vendor/bin/phpcs -p --extensions=php --standard=vendor/spryker/code-sniffer/Spryker/ruleset.xml src
+  - vendor/bin/phpstan analyze src/ -l 1
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ install:
 
 script:
   - vendor/bin/phpcs -p --extensions=php --standard=vendor/spryker/code-sniffer/Spryker/ruleset.xml src
-  - vendor/bin/phpstan analyze src/ -l 1
 
 notifications:
   email: false

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,9 @@
     "phpmd/phpmd": "^2.4"
   },
   "require-dev": {
-    "spryker/code-sniffer": "*",
-    "phpunit/phpunit": "~5.2"
+    "phpstan/phpstan": "^0.9.2",
+    "phpunit/phpunit": "~5.2",
+    "spryker/code-sniffer": "*"
   },
   "autoload": {
     "psr-4": {
@@ -35,6 +36,7 @@
   "include-path":  ["src/"],
   "scripts": {
     "cs-check": "vendor/bin/phpcs --standard=vendor/spryker/code-sniffer/Spryker/ruleset.xml -v --ignore=/architecture-sniffer/vendor/ ./",
-    "cs-fix": "vendor/bin/phpcbf --standard=vendor/spryker/code-sniffer/Spryker/ruleset.xml -v --ignore=/architecture-sniffer/vendor/ ./"
+    "cs-fix": "vendor/bin/phpcbf --standard=vendor/spryker/code-sniffer/Spryker/ruleset.xml -v --ignore=/architecture-sniffer/vendor/ ./",
+    "phpstan": "vendor/bin/phpstan analyze src/ -l 1"
   }
 }

--- a/src/Client/ClientInterfaceRule.php
+++ b/src/Client/ClientInterfaceRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Client;
 
 use ArchitectureSniffer\Common\ApiInterfaceRule;

--- a/src/Client/ClientRule.php
+++ b/src/Client/ClientRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Client;
 
 use ArchitectureSniffer\Common\ImplementsApiInterfaceRule;

--- a/src/Client/DependencyProvider/DependencyProviderMethodNameRule.php
+++ b/src/Client/DependencyProvider/DependencyProviderMethodNameRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Client\DependencyProvider;
 
 use ArchitectureSniffer\Common\DependencyProvider\AbstractDependencyProviderRule;

--- a/src/Client/NoClientInFrontendModuleRule.php
+++ b/src/Client/NoClientInFrontendModuleRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Client;
 
 use ArchitectureSniffer\Common\DeprecationTrait;

--- a/src/Common/ApiInterfaceRule.php
+++ b/src/Common/ApiInterfaceRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Common;
 
 use ArchitectureSniffer\SprykerAbstractRule;

--- a/src/Common/Communication/Controller/CommunicationControllerRule.php
+++ b/src/Common/Communication/Controller/CommunicationControllerRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Common\Communication\Controller;
 
 use PHPMD\AbstractNode;

--- a/src/Common/DependencyProvider/AbstractDependencyProviderRule.php
+++ b/src/Common/DependencyProvider/AbstractDependencyProviderRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Common\DependencyProvider;
 
 use ArchitectureSniffer\Common\DeprecationTrait;

--- a/src/Common/DeprecationTrait.php
+++ b/src/Common/DeprecationTrait.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * Copyright © 2017-present Spryker Systems GmbH. All rights reserved.
- * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
  */
 
 namespace ArchitectureSniffer\Common;

--- a/src/Common/EnforceAbstractionInConstructor.php
+++ b/src/Common/EnforceAbstractionInConstructor.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Common;
 
 use PDepend\Source\AST\ASTParameter;

--- a/src/Common/Factory/AbstractFactoryRule.php
+++ b/src/Common/Factory/AbstractFactoryRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Common\Factory;
 
 use ArchitectureSniffer\SprykerAbstractRule;

--- a/src/Common/Factory/FactoryCreateContainOneNewRule.php
+++ b/src/Common/Factory/FactoryCreateContainOneNewRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Common\Factory;
 
 use PHPMD\AbstractNode;

--- a/src/Common/Factory/FactoryGetContainNoNewRule.php
+++ b/src/Common/Factory/FactoryGetContainNoNewRule.php
@@ -1,4 +1,10 @@
 <?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Common\Factory;
 
 use PHPMD\AbstractNode;

--- a/src/Common/Factory/FactoryMethodReturnInterfaceRule.php
+++ b/src/Common/Factory/FactoryMethodReturnInterfaceRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Common\Factory;
 
 use PHPMD\AbstractNode;

--- a/src/Common/Factory/FactoryNoLogicRule.php
+++ b/src/Common/Factory/FactoryNoLogicRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Common\Factory;
 
 use PDepend\Source\AST\ASTSwitchStatement;

--- a/src/Common/Factory/FactoryNoLoopsRule.php
+++ b/src/Common/Factory/FactoryNoLoopsRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Common\Factory;
 
 use PHPMD\AbstractNode;

--- a/src/Common/Factory/FactoryOnlyGetAndCreateRule.php
+++ b/src/Common/Factory/FactoryOnlyGetAndCreateRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Common\Factory;
 
 use PHPMD\AbstractNode;

--- a/src/Common/ImplementsApiInterfaceRule.php
+++ b/src/Common/ImplementsApiInterfaceRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Common;
 
 use ArchitectureSniffer\SprykerAbstractRule;

--- a/src/Common/LayerAccessRule.php
+++ b/src/Common/LayerAccessRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Common;
 
 use PHPMD\AbstractNode;

--- a/src/Service/DependencyProvider/DependencyProviderMethodNameRule.php
+++ b/src/Service/DependencyProvider/DependencyProviderMethodNameRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Service\DependencyProvider;
 
 use ArchitectureSniffer\Common\DependencyProvider\AbstractDependencyProviderRule;

--- a/src/Service/ServiceInterfaceRule.php
+++ b/src/Service/ServiceInterfaceRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Service;
 
 use ArchitectureSniffer\Common\ApiInterfaceRule;

--- a/src/Service/ServiceRule.php
+++ b/src/Service/ServiceRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Service;
 
 use ArchitectureSniffer\Common\ImplementsApiInterfaceRule;

--- a/src/Shared/ModuleConstantsNoMethodAllowedRule.php
+++ b/src/Shared/ModuleConstantsNoMethodAllowedRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Shared;
 
 use PHPMD\AbstractNode;

--- a/src/Shared/ModuleConstantsRule.php
+++ b/src/Shared/ModuleConstantsRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Shared;
 
 use PHPMD\AbstractNode;

--- a/src/SprykerAbstractRule.php
+++ b/src/SprykerAbstractRule.php
@@ -1,42 +1,8 @@
 <?php
+
 /**
- * This file is part of PHP Mess Detector.
- *
- * Copyright (c) 2008-2017, Manuel Pichler <mapi@phpmd.org>.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- *   * Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer.
- *
- *   * Redistributions in binary form must reproduce the above copyright
- *     notice, this list of conditions and the following disclaimer in
- *     the documentation and/or other materials provided with the
- *     distribution.
- *
- *   * Neither the name of Manuel Pichler nor the names of his
- *     contributors may be used to endorse or promote products derived
- *     from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
- * @author Manuel Pichler <mapi@phpmd.org>
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
  */
 
 namespace ArchitectureSniffer;

--- a/src/SprykerRuleInterface.php
+++ b/src/SprykerRuleInterface.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer;
 
 interface SprykerRuleInterface

--- a/src/Yves/DependencyProvider/DependencyProviderMethodNameRule.php
+++ b/src/Yves/DependencyProvider/DependencyProviderMethodNameRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Yves\DependencyProvider;
 
 use ArchitectureSniffer\Common\DependencyProvider\AbstractDependencyProviderRule;

--- a/src/Zed/Business/Directory/AbstractDirectoryRule.php
+++ b/src/Zed/Business/Directory/AbstractDirectoryRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Zed\Business\Directory;
 
 use PHPMD\AbstractRule;

--- a/src/Zed/Business/Directory/AbstractDirectoryRule.php
+++ b/src/Zed/Business/Directory/AbstractDirectoryRule.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace ArchitectureSniffer\Zed\Business\Directory;
+
+use PHPMD\AbstractRule;
+use PHPMD\Node\AbstractNode;
+use PHPMD\Node\MethodNode;
+
+abstract class AbstractDirectoryRule extends AbstractRule
+{
+    /**
+     * @param \PHPMD\Node\AbstractNode $node
+     *
+     * @return bool
+     */
+    protected function isInBusinessLayer(AbstractNode $node)
+    {
+        if ($node instanceof MethodNode) {
+            $parent = $node->getNode()->getParent();
+            $className = $parent->getNamespaceName();
+        } else {
+            $className = $node->getFullQualifiedName();
+        }
+
+        if (preg_match('/\\\\Zed\\\\\w+\\\\Business\\\\/', $className)) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Zed/Business/Directory/DirectoryNoModelRule.php
+++ b/src/Zed/Business/Directory/DirectoryNoModelRule.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace ArchitectureSniffer\Zed\Business\Directory;
+
+use PHPMD\AbstractNode;
+use PHPMD\Node\ClassNode;
+use PHPMD\Rule\ClassAware;
+
+class DirectoryNoModelRule extends AbstractDirectoryRule implements ClassAware
+{
+    const RULE = 'Business models must not be in Model directory.';
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return static::RULE;
+    }
+
+    /**
+     * @param \PHPMD\AbstractNode $node
+     *
+     * @return void
+     */
+    public function apply(AbstractNode $node)
+    {
+        if (!$this->isInBusinessLayer($node)) {
+            return;
+        }
+
+        $this->applyRule($node);
+    }
+
+    /**
+     * @param ClassNode $classNode
+     *
+     * @return void
+     */
+    protected function applyRule(ClassNode $classNode)
+    {
+        if (!preg_match('/Business\\\\Model/', $classNode->getNamespaceName())) {
+            return;
+        }
+
+        $message = sprintf(
+            'The %s is inside a Model directory which violates rule "%s"',
+            $classNode->getFullQualifiedName(),
+            static::RULE
+        );
+
+        $this->addViolation($classNode, [$message]);
+    }
+}

--- a/src/Zed/Business/Directory/DirectoryNoModelRule.php
+++ b/src/Zed/Business/Directory/DirectoryNoModelRule.php
@@ -8,7 +8,7 @@ use PHPMD\Rule\ClassAware;
 
 class DirectoryNoModelRule extends AbstractDirectoryRule implements ClassAware
 {
-    const RULE = 'Business models must not be in Model directory.';
+    const RULE = 'Business models must not be in a Model directory.';
 
     /**
      * @return string
@@ -33,13 +33,13 @@ class DirectoryNoModelRule extends AbstractDirectoryRule implements ClassAware
     }
 
     /**
-     * @param ClassNode $classNode
+     * @param \PHPMD\Node\ClassNode $classNode
      *
      * @return void
      */
     protected function applyRule(ClassNode $classNode)
     {
-        if (!preg_match('/Business\\\\Model/', $classNode->getNamespaceName())) {
+        if (!preg_match('/Business\\\\Model\\\\/', $classNode->getFullQualifiedName())) {
             return;
         }
 

--- a/src/Zed/Business/Directory/DirectoryNoModelRule.php
+++ b/src/Zed/Business/Directory/DirectoryNoModelRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Zed\Business\Directory;
 
 use PHPMD\AbstractNode;

--- a/src/Zed/Business/Facade/AbstractFacadeRule.php
+++ b/src/Zed/Business/Facade/AbstractFacadeRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Zed\Business\Facade;
 
 use PHPMD\AbstractRule;

--- a/src/Zed/Business/Facade/AllMethodsPublicInFacadeRule.php
+++ b/src/Zed/Business/Facade/AllMethodsPublicInFacadeRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Zed\Business\Facade;
 
 use PHPMD\AbstractNode;

--- a/src/Zed/Business/Facade/FacadeArgumentsRule.php
+++ b/src/Zed/Business/Facade/FacadeArgumentsRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Zed\Business\Facade;
 
 use PDepend\Source\AST\ASTParameter;

--- a/src/Zed/Business/Facade/FacadeInterfaceRule.php
+++ b/src/Zed/Business/Facade/FacadeInterfaceRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Zed\Business\Facade;
 
 use PDepend\Source\AST\ASTArtifactList;

--- a/src/Zed/Business/Facade/FacadeNoLogicRule.php
+++ b/src/Zed/Business/Facade/FacadeNoLogicRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Zed\Business\Facade;
 
 use PHPMD\AbstractNode;

--- a/src/Zed/Business/Facade/FacadeReturnValueRule.php
+++ b/src/Zed/Business/Facade/FacadeReturnValueRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Zed\Business\Facade;
 
 use PHPMD\AbstractNode;

--- a/src/Zed/Business/Facade/FacadeRule.php
+++ b/src/Zed/Business/Facade/FacadeRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Zed\Business\Facade;
 
 use PHPMD\AbstractNode;

--- a/src/Zed/Business/Facade/FacadeSingleFactoryCallRule.php
+++ b/src/Zed/Business/Facade/FacadeSingleFactoryCallRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Zed\Business\Facade;
 
 use PHPMD\AbstractNode;

--- a/src/Zed/Dependency/Bridge/AbstractBridgeRule.php
+++ b/src/Zed/Dependency/Bridge/AbstractBridgeRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Zed\Dependency\Bridge;
 
 use PHPMD\AbstractRule;

--- a/src/Zed/Dependency/Bridge/BridgeConstructorArgumentTypehintsRule.php
+++ b/src/Zed/Dependency/Bridge/BridgeConstructorArgumentTypehintsRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Zed\Dependency\Bridge;
 
 use PDepend\Source\AST\ASTParameter;

--- a/src/Zed/Dependency/Bridge/BridgeConstructorArgumentsRule.php
+++ b/src/Zed/Dependency/Bridge/BridgeConstructorArgumentsRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Zed\Dependency\Bridge;
 
 use PHPMD\AbstractNode;

--- a/src/Zed/DependencyProvider/DependencyProviderMethodNameRule.php
+++ b/src/Zed/DependencyProvider/DependencyProviderMethodNameRule.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace ArchitectureSniffer\Zed\DependencyProvider;
 
 use ArchitectureSniffer\Common\DependencyProvider\AbstractDependencyProviderRule;

--- a/src/Zed/ruleset.xml
+++ b/src/Zed/ruleset.xml
@@ -91,4 +91,12 @@
         <priority>3</priority>
     </rule>
 
+    <!-- BUSINESS DIRECTORY RULES -->
+    <rule
+            name="ZedBusinessDirectoryNoModelRule"
+            message="Zed Business - Directory: {0}"
+            class="ArchitectureSniffer\Zed\Business\Directory\DirectoryNoModelRule">
+
+        <priority>3</priority>
+    </rule>
 </ruleset>


### PR DESCRIPTION
- Developer(s): @stereomon

- Peer Reviewer:

- Ticket: TICKET_URL_HERE

- Academy PR: ACADEMY_URL_HERE


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department
- [ ] All new or heavily changed classes get an "A" rating (Scrutinizer), except Facades, Factories, QueryContainers and Tests

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   ArchitectureSniffer   | minor (new)           |                       |

#### Release Notes

Added rule with priority 3 to ensure that Model as directory will no longer be used inside the Business layer.

-----------------------------------------

#### Module ArchitectureSniffer

_**Minor:** Added functionality in a backwards-compatible manner_

Def of done (by responsible developer):
- [ ] All changes are backward-compatible. Outdated code is marked as deprecated.
- [ ] New and changed facade methods covered by functional tests. / Has nothing to test.
- [ ] New and changed complex business logic is covered by unit or integration tests. / Has nothing to test.

##### Change log

Initial Release

- Added new DirectoryNoModelRule with priority 3.


