### PR TITLE
MISC check only business factory

### DIFF
--- a/src/Common/Factory/AbstractFactoryRule.php
+++ b/src/Common/Factory/AbstractFactoryRule.php
@@ -8,7 +8,7 @@ use PHPMD\Node\MethodNode;
 
 abstract class AbstractFactoryRule extends SprykerAbstractRule
 {
-    const PATTERN_ZED_FACTORY = '/\\\\*\\\\.+\\\\.+\\\\Business\\\\[^\\\\]+Factory$/';
+    const PATTERN_FACTORY = '/\\\\*\\\\.+\\\\.+\\\\[A-Za-z0-9]+(Business|Service|Communication)Factory$/';
 
     /**
      * @param \PHPMD\Node\AbstractNode $node
@@ -31,7 +31,7 @@ abstract class AbstractFactoryRule extends SprykerAbstractRule
             return false;
         }
 
-        if (preg_match(self::PATTERN_ZED_FACTORY, $className)) {
+        if (preg_match(self::PATTERN_FACTORY, $className)) {
             return true;
         }
 

--- a/src/Common/Factory/AbstractFactoryRule.php
+++ b/src/Common/Factory/AbstractFactoryRule.php
@@ -8,7 +8,7 @@ use PHPMD\Node\MethodNode;
 
 abstract class AbstractFactoryRule extends SprykerAbstractRule
 {
-    const PATTERN_ZED_FACTORY = '/\\\\+\\\\.+\\\\.+\\\\Business\\\\[^\\\\]+Factory$/';
+    const PATTERN_ZED_FACTORY = '/\\\\*\\\\.+\\\\.+\\\\Business\\\\[^\\\\]+Factory$/';
 
     /**
      * @param \PHPMD\Node\AbstractNode $node

--- a/src/Common/Factory/AbstractFactoryRule.php
+++ b/src/Common/Factory/AbstractFactoryRule.php
@@ -8,7 +8,7 @@ use PHPMD\Node\MethodNode;
 
 abstract class AbstractFactoryRule extends SprykerAbstractRule
 {
-    const PATTERN_ZED_FACTORY = '/\\\\*\\\\.+\\\\.+\\\\.+Factory$/';
+    const PATTERN_ZED_FACTORY = '/\\\\*\\\\.*\\\\.*\\\\Business\\\\[^\\\\]*Factory$/';
 
     /**
      * @param \PHPMD\Node\AbstractNode $node

--- a/src/Common/Factory/AbstractFactoryRule.php
+++ b/src/Common/Factory/AbstractFactoryRule.php
@@ -8,7 +8,7 @@ use PHPMD\Node\MethodNode;
 
 abstract class AbstractFactoryRule extends SprykerAbstractRule
 {
-    const PATTERN_ZED_FACTORY = '/\\\\*\\\\.*\\\\.*\\\\Business\\\\[^\\\\]*Factory$/';
+    const PATTERN_ZED_FACTORY = '/\\\\+\\\\.+\\\\.+\\\\Business\\\\[^\\\\]+Factory$/';
 
     /**
      * @param \PHPMD\Node\AbstractNode $node


### PR DESCRIPTION
This change prevents false-positive errors for custom factories, which require `__construct` method.

Maybe we can make regex even harder:
```    const PATTERN_ZED_FACTORY = '/\\\\*\\\\.*\\\\.*\\\\Business\\\\[^\\\\]*BusinessFactory$/';```

Sadly, we don't have tests for Common rules