### PR TITLE
TE-9766 Architecture sniffer false positive report fix

### DIFF
--- a/src/Common/Communication/Controller/CommunicationControllerRule.php
+++ b/src/Common/Communication/Controller/CommunicationControllerRule.php
@@ -42,7 +42,7 @@ class CommunicationControllerRule extends AbstractRule implements ClassAware
         if (preg_match('(\\\\[^\\\\]+Controller$)', $node->getFullQualifiedName()) === 0) {
             return;
         }
-        if ($node->getName() === 'AbstractController') {
+        if ($this->isAbstractController($node)) {
             return;
         }
 
@@ -50,6 +50,16 @@ class CommunicationControllerRule extends AbstractRule implements ClassAware
         foreach ($node->getMethods() as $method) {
             $this->applyPublicMethodsHaveActionSuffix($method);
         }
+    }
+
+    /**
+     * @param \PHPMD\AbstractNode $node
+     *
+     * @return bool
+     */
+    protected function isAbstractController(AbstractNode $node): bool
+    {
+        return $node->getName() === 'AbstractController' || $node->getName() === 'AbstractGatewayController';
     }
 
     /**

--- a/src/Zed/Business/Facade/AbstractFacadeRule.php
+++ b/src/Zed/Business/Facade/AbstractFacadeRule.php
@@ -33,4 +33,14 @@ abstract class AbstractFacadeRule extends AbstractRule
 
         return false;
     }
+
+    /**
+     * @param \PHPMD\Node\AbstractNode $node
+     *
+     * @return bool
+     */
+    protected function isAbstractFacade(AbstractNode $node): bool
+    {
+        return $node->getName() === 'AbstractFacade';
+    }
 }

--- a/src/Zed/Business/Facade/AllMethodsPublicInFacadeRule.php
+++ b/src/Zed/Business/Facade/AllMethodsPublicInFacadeRule.php
@@ -31,7 +31,7 @@ class AllMethodsPublicInFacadeRule extends AbstractFacadeRule implements ClassAw
      */
     public function apply(AbstractNode $node)
     {
-        if (!$this->isFacade($node)) {
+        if (!$this->isFacade($node) || $this->isAbstractFacade($node)) {
             return;
         }
 

--- a/src/Zed/Business/Facade/FacadeInterfaceRule.php
+++ b/src/Zed/Business/Facade/FacadeInterfaceRule.php
@@ -34,7 +34,7 @@ class FacadeInterfaceRule extends AbstractFacadeRule implements ClassAware
      */
     public function apply(AbstractNode $node)
     {
-        if (!$this->isFacade($node)) {
+        if (!$this->isFacade($node) || $this->isAbstractFacade($node)) {
             return;
         }
 

--- a/src/Zed/Dependency/Bridge/BridgeConstructorArgumentsRule.php
+++ b/src/Zed/Dependency/Bridge/BridgeConstructorArgumentsRule.php
@@ -71,7 +71,7 @@ class BridgeConstructorArgumentsRule extends AbstractBridgeRule implements Metho
      */
     protected function getInternalDependenciesCount(MethodNode $method): int
     {
-        preg_match_all('/@param \\\Spryker.*/', $method->getComment(), $matches);
+        preg_match_all('/@param \\\\Spryker.*\\\\/', $method->getComment(), $matches);
 
         return count($matches[0]);
     }

--- a/src/Zed/Dependency/Bridge/BridgeConstructorArgumentsRule.php
+++ b/src/Zed/Dependency/Bridge/BridgeConstructorArgumentsRule.php
@@ -13,7 +13,7 @@ use PHPMD\Rule\MethodAware;
 
 class BridgeConstructorArgumentsRule extends AbstractBridgeRule implements MethodAware
 {
-    public const RULE = 'A bridge should only have a single argument in constructor. It is also used only on core, not in projects.';
+    public const RULE = 'A bridge should only have a single internal dependency in constructor. It is also used only on core, not in projects.';
 
     /**
      * @return string
@@ -48,18 +48,31 @@ class BridgeConstructorArgumentsRule extends AbstractBridgeRule implements Metho
             return;
         }
 
-        $params = $method->getParameters();
-        if (count($params) === 1) {
+        $internalDependenciesCount = $this->getInternalDependenciesCount($method);
+
+        if ($internalDependenciesCount <= 1) {
             return;
         }
 
         $message = sprintf(
-            'The %s is having %s parameters which violates the rule "%s"',
-            count($params),
+            'The %s is having %s internal dependencies which violates the rule "%s"',
             $method->getFullQualifiedName(),
+            $internalDependenciesCount,
             static::RULE
         );
 
         $this->addViolation($method, [$message]);
+    }
+
+    /**
+     * @param \PHPMD\Node\MethodNode $method
+     *
+     * @return int
+     */
+    protected function getInternalDependenciesCount(MethodNode $method): int
+    {
+        preg_match_all('/@param \\\Spryker.*/', $method->getComment(), $matches);
+
+        return count($matches[0]);
     }
 }


### PR DESCRIPTION
- Developer(s): @asaulenko

- Ticket: https://spryker.atlassian.net/browse/TE-9578

- merge: merge

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   ArchitectureSniffer   | minor (currently 0.x)  |                       |

-----------------------------------------

#### Module ArchitectureSniffer

##### Change log

Initial Release

- Adjusted `CommunicationControllerRule` so it skips the check for `AbstractGatewayController`.
- Adjusted `AllMethodsPublicInFacadeRule` so it skips the check for `AbstractFacade`.
- Adjusted `FacadeInterfaceRule` so it skips the check for `AbstractFacade`.
- Adjusted `BridgeConstructorArgumentsRule` so it now checks the count of internal dependencies only.
