### PR TITLE
TE-9781: Fixed false-positive reports in ClientInterfaceRule and ApiI…

### DIFF
--- a/src/Client/ClientInterfaceRule.php
+++ b/src/Client/ClientInterfaceRule.php
@@ -15,5 +15,5 @@ class ClientInterfaceRule extends ApiInterfaceRule implements InterfaceAware
     /**
      * @var string
      */
-    protected $classRegex = '(\\\\Client\\\\.+ClientInterface$)';
+    protected $classRegex = '(\\\\Client\\\\[A-Za-z]+\\\\[A-Za-z]+ClientInterface$)';
 }

--- a/src/Common/ApiInterfaceRule.php
+++ b/src/Common/ApiInterfaceRule.php
@@ -81,7 +81,7 @@ class ApiInterfaceRule extends SprykerAbstractRule implements InterfaceAware
         if (
             preg_match(
                 '(
-                \*\s+[{}A-Z0-9\-]+.*\s+
+                \*\s+["{}\[\],=>$A-Z0-9\-]+.*\s+
                 \*?\s*
                 \*\s+@api
             )xi',


### PR DESCRIPTION
- Developer(s): @asaulenko

- Ticket: https://spryker.atlassian.net/browse/TE-9781

- Release Group: https://release.spryker.com/release-groups/view/3795

- merge: merge

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   ArchitectureSniffer   | patch (currently 0.x)  |                       |

-----------------------------------------

#### Module ArchitectureSniffer

##### Change log

### Fixes

- Adjusted `ClientInterfaceRule` so it is not applied to dependency interfaces.
- Adjusted `ApiInterfaceRule` so it correctly inspects method docblocks with example code snippets.
- Fixed ModuleConstantsFormingConstantValuesRule

### Improvements

- PHP 8 compatibility
- Added BridgeClassNamingRule and BridgeInterfaceNamingConventionRule
