### PR TITLE
TE-10481 Removed wrong message when bridge is stricter than parent class

### DIFF
--- a/tests/_data/Common/Bridge/BridgeMethodsTest/testRuleAppliesWhenBridgeMethodsAreNotCorrect.php
+++ b/tests/_data/Common/Bridge/BridgeMethodsTest/testRuleAppliesWhenBridgeMethodsAreNotCorrect.php
@@ -18,14 +18,14 @@ class SessionToDatabaseClientBridge implements SessionToDatabaseClientInterface
     {
     }
 
-    public function save(string $key, ExtendedDataObject $data, string $prefix = null, int $delay = null)
+    public function save(string $key, ExtendedDataObject $data, string $prefix = null, $options = null, int $delay = null )
     {
     }
 }
 
 interface SessionToDatabaseClientInterface
 {
-    public function save(string $key, ExtendedDataObject $data, string $prefix = null);
+    public function save(string $key, ExtendedDataObject $data, string $prefix = null, $options = null);
 }
 
 // Database module
@@ -36,7 +36,7 @@ use DataLayer\DataObject;
 
 interface DatabaseClientInterface
 {
-    public function save(string $key, DataObject $data, string $prefix = null);
+    public function save(string $key, DataObject $data, string $prefix = null, array $options = null);
 }
 
 // Data objects

--- a/tests/_data/Common/Bridge/BridgeMethodsTest/testRuleDoesNotApplyWhenBridgeMethodsAreCorrect.php
+++ b/tests/_data/Common/Bridge/BridgeMethodsTest/testRuleDoesNotApplyWhenBridgeMethodsAreCorrect.php
@@ -44,5 +44,5 @@ use StructuredData\DataObject;
 
 interface CacheClientInterface
 {
-    public function save(string $key, DataObject $data, string $prefix = null);
+    public function save(string $key, DataObject $data, $prefix = null, array $options = null);
 }


### PR DESCRIPTION
- Developer(s): @geega

- Ticket: https://spryker.atlassian.net/browse/TE-10481

- Docs PR: ACADEMY_URL_HERE

- Release Group: https://release.spryker.com/release-groups/view/3930

- merge: merge

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   ArchitectureSniffer              | minor                 |                       |

-----------------------------------------

#### Module ArchitectureSniffer

##### Change log

Improvements

- Adjusted `BridgeMethodsRule` so it fixes the wrong message when the bridge is stricter than the parent class.
