### PR TITLE
TE-10470 Create architecture sniffer rule for get function prefix

### DIFF
--- a/src/Common/DeprecationTrait.php
+++ b/src/Common/DeprecationTrait.php
@@ -24,7 +24,13 @@ trait DeprecationTrait
      */
     protected function isMethodDeprecated(MethodNode $method)
     {
-        return (bool)preg_match($this->regexp, $method->getNode()->getDocComment());
+        $comment = $method->getNode()->getComment();
+
+        if ($comment === null) {
+            return false;
+        }
+
+        return (bool)preg_match($this->regexp, $comment);
     }
 
     /**
@@ -34,6 +40,12 @@ trait DeprecationTrait
      */
     protected function isClassDeprecated(ClassNode $classNode)
     {
-        return (bool)preg_match($this->regexp, $classNode->getNode()->getDocComment());
+        $comment = $classNode->getNode()->getComment();
+
+        if ($comment === null) {
+            return false;
+        }
+
+        return (bool)preg_match($this->regexp, $classNode->getNode()->getComment());
     }
 }

--- a/src/Common/Method/ExistsPostfixRule.php
+++ b/src/Common/Method/ExistsPostfixRule.php
@@ -7,6 +7,7 @@
 
 namespace ArchitectureSniffer\Common\Method;
 
+use ArchitectureSniffer\Common\DeprecationTrait;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Node\ClassNode;
@@ -15,6 +16,8 @@ use PHPMD\Rule\ClassAware;
 
 class ExistsPostfixRule extends AbstractRule implements ClassAware
 {
+    use DeprecationTrait;
+
     /**
      * @var string
      */
@@ -62,7 +65,10 @@ class ExistsPostfixRule extends AbstractRule implements ClassAware
      */
     public function apply(AbstractNode $node)
     {
-        if (!$node instanceof ClassNode) {
+        if (
+            !$node instanceof ClassNode
+            || $this->isClassDeprecated($node)
+        ) {
             return;
         }
 
@@ -82,6 +88,7 @@ class ExistsPostfixRule extends AbstractRule implements ClassAware
 
         if (
             strpos($methodName, static::PREFIX_METHOD_NAME) !== 0
+            || $this->isMethodDeprecated($methodNode)
             || !preg_match(static::POSTFIX_PATTERN, $methodName)
         ) {
             return;

--- a/src/Common/Method/ExistsPostfixRule.php
+++ b/src/Common/Method/ExistsPostfixRule.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace ArchitectureSniffer\Common\Method;
+
+use PHPMD\AbstractNode;
+use PHPMD\AbstractRule;
+use PHPMD\Node\ClassNode;
+use PHPMD\Node\MethodNode;
+use PHPMD\Rule\ClassAware;
+
+class ExistsPostfixRule extends AbstractRule implements ClassAware
+{
+    /**
+     * @var string
+     */
+    protected const POSTFIX_EXISTS = 'Exists';
+
+    /**
+     * @var string
+     */
+    protected const POSTFIX_EXIST = 'Exist';
+
+    /**
+     * @var string
+     */
+    protected const PREFIX_METHOD_NAME = 'is';
+
+    /**
+     * @var string
+     */
+    protected const RULE_EXISTS_INSTEAD_OF_EXIST = 'Postfix `Exists` must be used instead of `Exist`. Method: %s.';
+
+    /**
+     * @var string
+     */
+    protected const RULE_EXISTS_IN_THE_END = 'Postfix `Exists` must be in the end of method name. Method: %s.';
+
+    /**
+     * @var string
+     */
+    protected const RULE_FORBIDDEN_PREFIX_IS = 'Prefix `is` must not be used with postfix `Exists`. Method: %s.';
+
+    /**
+     * @param \PHPMD\AbstractNode $node
+     *
+     * @return void
+     */
+    public function apply(AbstractNode $node)
+    {
+        if (!$node instanceof ClassNode) {
+            return;
+        }
+
+        foreach ($node->getMethods() as $methodNode) {
+            $this->verifyMethod($methodNode);
+        }
+    }
+
+    /**
+     * @param \PHPMD\Node\MethodNode $methodNode
+     *
+     * @return void
+     */
+    protected function verifyMethod(MethodNode $methodNode): void
+    {
+        $methodName = $methodNode->getName();
+
+        if (strpos($methodName, static::POSTFIX_EXIST) === false) {
+            return;
+        }
+
+        if (strpos($methodName, static::PREFIX_METHOD_NAME) === 0) {
+            $this->addForbiddenPrefixViolation($methodNode);
+        }
+
+        if (strpos($methodName, static::POSTFIX_EXISTS) === false) {
+            $this->addPostfixSpellingViolation($methodNode);
+        }
+
+        $trimmedMethodName = rtrim($methodName, 's');
+        if (strpos($trimmedMethodName, static::POSTFIX_EXIST) !== strlen($trimmedMethodName) - strlen(static::POSTFIX_EXIST)) {
+            $this->addPostfixInEndViolation($methodNode);
+        }
+    }
+
+    /**
+     * @param \PHPMD\Node\MethodNode $methodNode
+     *
+     * @return void
+     */
+    protected function addPostfixSpellingViolation(MethodNode $methodNode): void
+    {
+        $message = sprintf(
+            static::RULE_EXISTS_INSTEAD_OF_EXIST,
+            $methodNode->getFullQualifiedName(),
+        );
+
+        $this->addViolation($methodNode, [$message]);
+    }
+
+    /**
+     * @param \PHPMD\Node\MethodNode $methodNode
+     *
+     * @return void
+     */
+    protected function addPostfixInEndViolation(MethodNode $methodNode): void
+    {
+        $message = sprintf(
+            static::RULE_EXISTS_IN_THE_END,
+            $methodNode->getFullQualifiedName(),
+        );
+
+        $this->addViolation($methodNode, [$message]);
+    }
+
+    /**
+     * @param \PHPMD\Node\MethodNode $methodNode
+     *
+     * @return void
+     */
+    protected function addForbiddenPrefixViolation(MethodNode $methodNode): void
+    {
+        $message = sprintf(
+            static::RULE_FORBIDDEN_PREFIX_IS,
+            $methodNode->getFullQualifiedName(),
+        );
+
+        $this->addViolation($methodNode, [$message]);
+    }
+}

--- a/src/Common/Method/ExistsPostfixRule.php
+++ b/src/Common/Method/ExistsPostfixRule.php
@@ -18,12 +18,22 @@ class ExistsPostfixRule extends AbstractRule implements ClassAware
     /**
      * @var string
      */
+    protected const POSTFIX_PATTERN = '/Exists?([A-Z]|$)/';
+
+    /**
+     * @var string
+     */
     protected const POSTFIX_EXISTS = 'Exists';
 
     /**
      * @var string
      */
     protected const POSTFIX_EXIST = 'Exist';
+
+    /**
+     * @var string
+     */
+    protected const POSTFIX_EXISTING = 'Existing';
 
     /**
      * @var string
@@ -43,7 +53,7 @@ class ExistsPostfixRule extends AbstractRule implements ClassAware
     /**
      * @var string
      */
-    protected const RULE_FORBIDDEN_PREFIX_IS = 'Prefix `is` must not be used with postfix `Exists`. Method: %s.';
+    protected const RULE_FORBIDDEN_PREFIX_IS = 'Prefix `is` must not be used with postfix `Exist`. Method: %s.';
 
     /**
      * @param \PHPMD\AbstractNode $node
@@ -70,13 +80,14 @@ class ExistsPostfixRule extends AbstractRule implements ClassAware
     {
         $methodName = $methodNode->getName();
 
-        if (strpos($methodName, static::POSTFIX_EXIST) === false) {
+        if (
+            strpos($methodName, static::PREFIX_METHOD_NAME) !== 0
+            || !preg_match(static::POSTFIX_PATTERN, $methodName)
+        ) {
             return;
         }
 
-        if (strpos($methodName, static::PREFIX_METHOD_NAME) === 0) {
-            $this->addForbiddenPrefixViolation($methodNode);
-        }
+        $this->addForbiddenPrefixViolation($methodNode);
 
         if (strpos($methodName, static::POSTFIX_EXISTS) === false) {
             $this->addPostfixSpellingViolation($methodNode);

--- a/src/Common/Method/GetterReturnTypeRule.php
+++ b/src/Common/Method/GetterReturnTypeRule.php
@@ -32,6 +32,11 @@ class GetterReturnTypeRule extends AbstractRule implements ClassAware
     /**
      * @var string
      */
+    protected const PATTERN_API_DOC  = '/@api/i';
+
+    /**
+     * @var string
+     */
     protected const PREFIX_METHOD_NAME = 'get';
 
     /**
@@ -79,6 +84,7 @@ class GetterReturnTypeRule extends AbstractRule implements ClassAware
 
         if (
             strpos($methodName, static::PREFIX_METHOD_NAME) !== 0
+            || !$this->apiTagExists($methodNode)
             || $this->isMethodDeprecated($methodNode)
             || strpos($methodName, static::EXCEPTIONAL_POSTFIX_STATUS) === strlen($methodName) - strlen(static::EXCEPTIONAL_POSTFIX_STATUS)
         ) {
@@ -88,7 +94,7 @@ class GetterReturnTypeRule extends AbstractRule implements ClassAware
         $returnType = $this->getReturnType($methodNode);
 
         if (
-            $returnType === null && !$this->inheritDocBlockExists($methodNode)
+            $returnType === null && !$this->inheritDocTagExists($methodNode)
             || $returnType === 'void'
         ) {
             $this->addMethodMustReturnViolation($methodNode);
@@ -106,7 +112,7 @@ class GetterReturnTypeRule extends AbstractRule implements ClassAware
      *
      * @return bool
      */
-    protected function inheritDocBlockExists(MethodNode $methodNode): bool
+    protected function inheritDocTagExists(MethodNode $methodNode): bool
     {
         $comment = $methodNode->getNode()->getComment();
 
@@ -115,6 +121,22 @@ class GetterReturnTypeRule extends AbstractRule implements ClassAware
         }
 
         return (bool)preg_match(static::PATTERN_INHERIT_DOC, $comment);
+    }
+
+    /**
+     * @param \PHPMD\Node\MethodNode $methodNode
+     *
+     * @return bool
+     */
+    protected function apiTagExists(MethodNode $methodNode): bool
+    {
+        $comment = $methodNode->getNode()->getComment();
+
+        if ($comment === null) {
+            return false;
+        }
+
+        return (bool)preg_match(static::PATTERN_API_DOC, $comment);
     }
 
     /**

--- a/src/Common/Method/GetterReturnTypeRule.php
+++ b/src/Common/Method/GetterReturnTypeRule.php
@@ -1,0 +1,175 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace ArchitectureSniffer\Common\Method;
+
+use PDepend\Source\AST\ASTCallable;
+use PHPMD\AbstractNode;
+use PHPMD\AbstractRule;
+use PHPMD\Node\ClassNode;
+use PHPMD\Node\MethodNode;
+use PHPMD\Rule\ClassAware;
+
+class GetterReturnTypeRule extends AbstractRule implements ClassAware
+{
+    /**
+     * @var string
+     */
+    protected const PATTER_RETURN = '/@return\s+([^\s]+)/';
+
+    /**
+     * @var string
+     */
+    protected const PATTERN_INHERIT_DOC = '/@inheritDoc/i';
+
+    /**
+     * @var string
+     */
+    protected const PREFIX_METHOD_NAME = 'get';
+
+    /**
+     * @var string
+     */
+    protected const RULE_RETURN_TYPE_SPECIFIED = 'Getter `%s` must return something. Please add return type.';
+
+    /**
+     * @var string
+     */
+    protected const RULE_RETURN_NOT_BOOL = 'Getter `%s` must not return bool.';
+
+    /**
+     * @param \PHPMD\AbstractNode $node
+     *
+     * @return void
+     */
+    public function apply(AbstractNode $node)
+    {
+        if (!$node instanceof ClassNode) {
+            return;
+        }
+
+        foreach ($node->getMethods() as $methodNode) {
+            $this->verifyMethod($methodNode);
+        }
+    }
+
+    /**
+     * @param \PHPMD\Node\MethodNode $methodNode
+     *
+     * @return void
+     */
+    protected function verifyMethod(MethodNode $methodNode): void
+    {
+        if (strpos($methodNode->getName(), static::PREFIX_METHOD_NAME) !== 0) {
+            return;
+        }
+
+        $returnType = $this->getReturnType($methodNode);
+
+        if (
+            $returnType === null && !$this->isInheritDocBlockExist($methodNode)
+            || $returnType === 'void'
+        ) {
+            $this->addMethodMustReturnViolation($methodNode);
+
+            return;
+        }
+
+        if ($returnType === 'bool') {
+            $this->addMethodReturnBoolViolation($methodNode);
+        }
+    }
+
+    /**
+     * @param \PHPMD\Node\MethodNode $methodNode
+     *
+     * @return bool
+     */
+    protected function isInheritDocBlockExist(MethodNode $methodNode): bool
+    {
+        $comment = $methodNode->getNode()->getComment();
+
+        if ($comment === null) {
+            return false;
+        }
+
+        return (bool)preg_match(static::PATTERN_INHERIT_DOC, $comment);
+    }
+
+    /**
+     * @param \PHPMD\Node\MethodNode $methodNode
+     *
+     * @return string|null
+     */
+    protected function getReturnType(MethodNode $methodNode): ?string
+    {
+        $artifact = $methodNode->getNode();
+
+        if (!$artifact instanceof ASTCallable) {
+            return null;
+        }
+
+        /** @var \PDepend\Source\AST\ASTType|null $returnType */
+        $returnType = $artifact->getReturnType();
+
+        if ($returnType !== null) {
+            return $returnType->getImage();
+        }
+
+        $phpDoc = $artifact->getComment();
+
+        if ($phpDoc === null) {
+            return null;
+        }
+
+        return $this->getReturnTypeByPhpDoc($phpDoc);
+    }
+
+    /**
+     * @param string $phpDoc
+     *
+     * @return string|null
+     */
+    protected function getReturnTypeByPhpDoc(string $phpDoc): ?string
+    {
+        $matches = [];
+
+        preg_match_all(static::PATTER_RETURN, $phpDoc, $matches);
+
+        return $matches[1][0] ?? null;
+    }
+
+    /**
+     * @param \PHPMD\Node\MethodNode $methodNode
+     *
+     * @return void
+     */
+    protected function addMethodReturnBoolViolation(MethodNode $methodNode): void
+    {
+        $message = sprintf(
+            static::RULE_RETURN_NOT_BOOL,
+            $methodNode->getFullQualifiedName(),
+        );
+
+        $this->addViolation($methodNode, [$message]);
+    }
+
+    /**
+     * @param \PHPMD\Node\MethodNode $methodNode
+     *
+     * @return void
+     */
+    protected function addMethodMustReturnViolation(MethodNode $methodNode): void
+    {
+        $message = sprintf(
+            static::RULE_RETURN_TYPE_SPECIFIED,
+            $methodNode->getFullQualifiedName(),
+        );
+
+        $this->addViolation($methodNode, [$message]);
+    }
+}

--- a/src/Common/Method/GetterReturnTypeRule.php
+++ b/src/Common/Method/GetterReturnTypeRule.php
@@ -47,7 +47,7 @@ class GetterReturnTypeRule extends AbstractRule implements ClassAware
     /**
      * @var string
      */
-    protected const RULE_RETURN_NOT_BOOL = 'Getter `%s` must not return bool.';
+    protected const RULE_RETURN_NOT_BOOL = 'Boolean methods do not use `get` prefix, use `is`/`has` instead or alike. Getter `%s` must not return bool.';
 
     /**
      * @param \PHPMD\AbstractNode $node

--- a/src/Common/Method/GetterReturnTypeRule.php
+++ b/src/Common/Method/GetterReturnTypeRule.php
@@ -7,6 +7,7 @@
 
 namespace ArchitectureSniffer\Common\Method;
 
+use ArchitectureSniffer\Common\DeprecationTrait;
 use PDepend\Source\AST\ASTCallable;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
@@ -16,6 +17,8 @@ use PHPMD\Rule\ClassAware;
 
 class GetterReturnTypeRule extends AbstractRule implements ClassAware
 {
+    use DeprecationTrait;
+
     /**
      * @var string
      */
@@ -53,7 +56,10 @@ class GetterReturnTypeRule extends AbstractRule implements ClassAware
      */
     public function apply(AbstractNode $node)
     {
-        if (!$node instanceof ClassNode) {
+        if (
+            !$node instanceof ClassNode
+            || $this->isClassDeprecated($node)
+        ) {
             return;
         }
 
@@ -73,6 +79,7 @@ class GetterReturnTypeRule extends AbstractRule implements ClassAware
 
         if (
             strpos($methodName, static::PREFIX_METHOD_NAME) !== 0
+            || $this->isMethodDeprecated($methodNode)
             || strpos($methodName, static::EXCEPTIONAL_POSTFIX_STATUS) === strlen($methodName) - strlen(static::EXCEPTIONAL_POSTFIX_STATUS)
         ) {
             return;

--- a/src/Common/Method/GetterReturnTypeRule.php
+++ b/src/Common/Method/GetterReturnTypeRule.php
@@ -34,6 +34,11 @@ class GetterReturnTypeRule extends AbstractRule implements ClassAware
     /**
      * @var string
      */
+    protected const EXCEPTIONAL_POSTFIX_STATUS = 'Status';
+
+    /**
+     * @var string
+     */
     protected const RULE_RETURN_TYPE_SPECIFIED = 'Getter `%s` must return something. Please add return type.';
 
     /**
@@ -64,7 +69,12 @@ class GetterReturnTypeRule extends AbstractRule implements ClassAware
      */
     protected function verifyMethod(MethodNode $methodNode): void
     {
-        if (strpos($methodNode->getName(), static::PREFIX_METHOD_NAME) !== 0) {
+        $methodName = $methodNode->getName();
+
+        if (
+            strpos($methodName, static::PREFIX_METHOD_NAME) !== 0
+            || strpos($methodName, static::EXCEPTIONAL_POSTFIX_STATUS) === strlen($methodName) - strlen(static::EXCEPTIONAL_POSTFIX_STATUS)
+        ) {
             return;
         }
 

--- a/src/Common/Method/GetterReturnTypeRule.php
+++ b/src/Common/Method/GetterReturnTypeRule.php
@@ -32,7 +32,7 @@ class GetterReturnTypeRule extends AbstractRule implements ClassAware
     /**
      * @var string
      */
-    protected const PATTERN_API_DOC  = '/@api/i';
+    protected const PATTERN_API_DOC = '/@api/i';
 
     /**
      * @var string

--- a/src/Common/Method/GetterReturnTypeRule.php
+++ b/src/Common/Method/GetterReturnTypeRule.php
@@ -71,7 +71,7 @@ class GetterReturnTypeRule extends AbstractRule implements ClassAware
         $returnType = $this->getReturnType($methodNode);
 
         if (
-            $returnType === null && !$this->isInheritDocBlockExist($methodNode)
+            $returnType === null && !$this->inheritDocBlockExists($methodNode)
             || $returnType === 'void'
         ) {
             $this->addMethodMustReturnViolation($methodNode);
@@ -89,7 +89,7 @@ class GetterReturnTypeRule extends AbstractRule implements ClassAware
      *
      * @return bool
      */
-    protected function isInheritDocBlockExist(MethodNode $methodNode): bool
+    protected function inheritDocBlockExists(MethodNode $methodNode): bool
     {
         $comment = $methodNode->getNode()->getComment();
 

--- a/src/Common/ruleset.xml
+++ b/src/Common/ruleset.xml
@@ -34,6 +34,14 @@
         <priority>1</priority>
     </rule>
 
+    <rule
+            name="ExistsPostfixRule"
+            message="{0}"
+            class="ArchitectureSniffer\Common\Method\ExistsPostfixRule">
+
+        <priority>1</priority>
+    </rule>
+
     <!-- COMMON FACTORY RULES -->
     <rule
             name="FactoryGetContainNoNewRule"

--- a/src/Common/ruleset.xml
+++ b/src/Common/ruleset.xml
@@ -26,6 +26,14 @@
         <priority>3</priority>
     </rule>
 
+    <rule
+            name="GetterReturnTypeRule"
+            message="{0}"
+            class="ArchitectureSniffer\Common\Method\GetterReturnTypeRule">
+
+        <priority>1</priority>
+    </rule>
+
     <!-- COMMON FACTORY RULES -->
     <rule
             name="FactoryGetContainNoNewRule"

--- a/tests/Common/Method/ExistsPostfixRuleTest.php
+++ b/tests/Common/Method/ExistsPostfixRuleTest.php
@@ -45,6 +45,26 @@ class ExistsPostfixRuleTest extends AbstractArchitectureSnifferRuleTest
     /**
      * @return void
      */
+    public function testRuleDoesNotApplyWhenMethodIsDeprecated(): void
+    {
+        $bridgePathRule = new ExistsPostfixRule();
+        $bridgePathRule->setReport($this->getReportMock(0));
+        $bridgePathRule->apply($this->getClassNode());
+    }
+
+    /**
+     * @return void
+     */
+    public function testRuleDoesNotApplyWhenClassIsDeprecated(): void
+    {
+        $bridgePathRule = new ExistsPostfixRule();
+        $bridgePathRule->setReport($this->getReportMock(0));
+        $bridgePathRule->apply($this->getClassNode());
+    }
+
+    /**
+     * @return void
+     */
     public function testRuleAppliesWhenForbiddenPrefixPresentAndPostfixIncorrect(): void
     {
         $bridgePathRule = new ExistsPostfixRule();

--- a/tests/Common/Method/ExistsPostfixRuleTest.php
+++ b/tests/Common/Method/ExistsPostfixRuleTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace ArchitectureSnifferTest\Common\Method;
+
+use ArchitectureSniffer\Common\Method\ExistsPostfixRule;
+use ArchitectureSnifferTest\AbstractArchitectureSnifferRuleTest;
+
+class ExistsPostfixRuleTest extends AbstractArchitectureSnifferRuleTest
+{
+    /**
+     * @return void
+     */
+    public function testRuleDoesNotApplyWhenPostfixCorrect(): void
+    {
+        $bridgePathRule = new ExistsPostfixRule();
+        $bridgePathRule->setReport($this->getReportMock(0));
+        $bridgePathRule->apply($this->getClassNode());
+    }
+
+    /**
+     * @return void
+     */
+    public function testRuleAppliesWhenForbiddenPrefixPresentAndPostfixIncorrect(): void
+    {
+        $bridgePathRule = new ExistsPostfixRule();
+        $bridgePathRule->setReport($this->getReportMock(3));
+        $bridgePathRule->apply($this->getClassNode());
+    }
+}

--- a/tests/Common/Method/ExistsPostfixRuleTest.php
+++ b/tests/Common/Method/ExistsPostfixRuleTest.php
@@ -25,6 +25,26 @@ class ExistsPostfixRuleTest extends AbstractArchitectureSnifferRuleTest
     /**
      * @return void
      */
+    public function testRuleDoesNotApplyWhenWordExistingUsed(): void
+    {
+        $bridgePathRule = new ExistsPostfixRule();
+        $bridgePathRule->setReport($this->getReportMock(0));
+        $bridgePathRule->apply($this->getClassNode());
+    }
+
+    /**
+     * @return void
+     */
+    public function testRuleDoesNotApplyWithoutForbiddenPrefix(): void
+    {
+        $bridgePathRule = new ExistsPostfixRule();
+        $bridgePathRule->setReport($this->getReportMock(0));
+        $bridgePathRule->apply($this->getClassNode());
+    }
+
+    /**
+     * @return void
+     */
     public function testRuleAppliesWhenForbiddenPrefixPresentAndPostfixIncorrect(): void
     {
         $bridgePathRule = new ExistsPostfixRule();

--- a/tests/Common/Method/GetterReturnTypeRuleTest.php
+++ b/tests/Common/Method/GetterReturnTypeRuleTest.php
@@ -75,7 +75,17 @@ class GetterReturnTypeRuleTest extends AbstractArchitectureSnifferRuleTest
     /**
      * @return void
      */
-    public function testRuleDoesNotApplyWhenInheritDocBlockExists(): void
+    public function testRuleDoesNotApplyWhenInheritDocTagExists(): void
+    {
+        $bridgePathRule = new GetterReturnTypeRule();
+        $bridgePathRule->setReport($this->getReportMock(0));
+        $bridgePathRule->apply($this->getClassNode());
+    }
+
+    /**
+     * @return void
+     */
+    public function testRuleDoesNotApplyWhenApiTagDoesNotExist(): void
     {
         $bridgePathRule = new GetterReturnTypeRule();
         $bridgePathRule->setReport($this->getReportMock(0));

--- a/tests/Common/Method/GetterReturnTypeRuleTest.php
+++ b/tests/Common/Method/GetterReturnTypeRuleTest.php
@@ -95,6 +95,26 @@ class GetterReturnTypeRuleTest extends AbstractArchitectureSnifferRuleTest
     /**
      * @return void
      */
+    public function testRuleDoesNotApplyWhenMethodIsDeprecated(): void
+    {
+        $bridgePathRule = new GetterReturnTypeRule();
+        $bridgePathRule->setReport($this->getReportMock(0));
+        $bridgePathRule->apply($this->getClassNode());
+    }
+
+    /**
+     * @return void
+     */
+    public function testRuleDoesNotApplyWhenClassIsDeprecated(): void
+    {
+        $bridgePathRule = new GetterReturnTypeRule();
+        $bridgePathRule->setReport($this->getReportMock(0));
+        $bridgePathRule->apply($this->getClassNode());
+    }
+
+    /**
+     * @return void
+     */
     public function testRuleAppliesWhenBoolReturnTypeSpecified(): void
     {
         $bridgePathRule = new GetterReturnTypeRule();

--- a/tests/Common/Method/GetterReturnTypeRuleTest.php
+++ b/tests/Common/Method/GetterReturnTypeRuleTest.php
@@ -85,6 +85,16 @@ class GetterReturnTypeRuleTest extends AbstractArchitectureSnifferRuleTest
     /**
      * @return void
      */
+    public function testRuleDoesNotApplyWhenMethodNameHasPostfixStatus(): void
+    {
+        $bridgePathRule = new GetterReturnTypeRule();
+        $bridgePathRule->setReport($this->getReportMock(0));
+        $bridgePathRule->apply($this->getClassNode());
+    }
+
+    /**
+     * @return void
+     */
     public function testRuleAppliesWhenBoolReturnTypeSpecified(): void
     {
         $bridgePathRule = new GetterReturnTypeRule();

--- a/tests/Common/Method/GetterReturnTypeRuleTest.php
+++ b/tests/Common/Method/GetterReturnTypeRuleTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace ArchitectureSnifferTest\Common\Method;
+
+use ArchitectureSniffer\Common\Method\GetterReturnTypeRule;
+use ArchitectureSnifferTest\AbstractArchitectureSnifferRuleTest;
+
+class GetterReturnTypeRuleTest extends AbstractArchitectureSnifferRuleTest
+{
+    /**
+     * @return void
+     */
+    public function testRuleDoesNotApplyWhenNotBoolScalarReturnTypeSpecified(): void
+    {
+        $bridgePathRule = new GetterReturnTypeRule();
+        $bridgePathRule->setReport($this->getReportMock(0));
+        $bridgePathRule->apply($this->getClassNode());
+    }
+
+    /**
+     * @return void
+     */
+    public function testRuleDoesNotApplyWhenMixedReturnTypeSpecified(): void
+    {
+        $bridgePathRule = new GetterReturnTypeRule();
+        $bridgePathRule->setReport($this->getReportMock(0));
+        $bridgePathRule->apply($this->getClassNode());
+    }
+
+    /**
+     * @return void
+     */
+    public function testRuleDoesNotApplyWhenClassReturnTypeSpecified(): void
+    {
+        $bridgePathRule = new GetterReturnTypeRule();
+        $bridgePathRule->setReport($this->getReportMock(0));
+        $bridgePathRule->apply($this->getClassNode());
+    }
+
+    /**
+     * @return void
+     */
+    public function testRuleDoesNotApplyWhenNotBoolScalarReturnTypeSpecifiedInPhpDoc(): void
+    {
+        $bridgePathRule = new GetterReturnTypeRule();
+        $bridgePathRule->setReport($this->getReportMock(0));
+        $bridgePathRule->apply($this->getClassNode());
+    }
+
+    /**
+     * @return void
+     */
+    public function testRuleDoesNotApplyWhenClassReturnTypeSpecifiedInPhpDoc(): void
+    {
+        $bridgePathRule = new GetterReturnTypeRule();
+        $bridgePathRule->setReport($this->getReportMock(0));
+        $bridgePathRule->apply($this->getClassNode());
+    }
+
+    /**
+     * @return void
+     */
+    public function testRuleDoesNotApplyWhenBoolReturnTypeSpecifiedForNotGetter(): void
+    {
+        $bridgePathRule = new GetterReturnTypeRule();
+        $bridgePathRule->setReport($this->getReportMock(0));
+        $bridgePathRule->apply($this->getClassNode());
+    }
+
+    /**
+     * @return void
+     */
+    public function testRuleDoesNotApplyWhenInheritDocBlockExists(): void
+    {
+        $bridgePathRule = new GetterReturnTypeRule();
+        $bridgePathRule->setReport($this->getReportMock(0));
+        $bridgePathRule->apply($this->getClassNode());
+    }
+
+    /**
+     * @return void
+     */
+    public function testRuleAppliesWhenBoolReturnTypeSpecified(): void
+    {
+        $bridgePathRule = new GetterReturnTypeRule();
+        $bridgePathRule->setReport($this->getReportMock(1));
+        $bridgePathRule->apply($this->getClassNode());
+    }
+
+    /**
+     * @return void
+     */
+    public function testRuleAppliesWhenBoolReturnTypeSpecifiedInPhpDoc(): void
+    {
+        $bridgePathRule = new GetterReturnTypeRule();
+        $bridgePathRule->setReport($this->getReportMock(1));
+        $bridgePathRule->apply($this->getClassNode());
+    }
+
+    /**
+     * @return void
+     */
+    public function testRuleAppliesWhenReturnTypeNotSpecified(): void
+    {
+        $bridgePathRule = new GetterReturnTypeRule();
+        $bridgePathRule->setReport($this->getReportMock(1));
+        $bridgePathRule->apply($this->getClassNode());
+    }
+
+    /**
+     * @return void
+     */
+    public function testRuleAppliesWhenVoidReturnTypeSpecified(): void
+    {
+        $bridgePathRule = new GetterReturnTypeRule();
+        $bridgePathRule->setReport($this->getReportMock(1));
+        $bridgePathRule->apply($this->getClassNode());
+    }
+}

--- a/tests/Common/codeception.yml
+++ b/tests/Common/codeception.yml
@@ -30,3 +30,9 @@ suites:
     modules:
       enabled:
         - Asserts
+  Method:
+    path: Method
+    class_name: CommonTester
+    modules:
+      enabled:
+        - Asserts

--- a/tests/_data/Common/Method/ExistsPostfixRuleTest/testRuleAppliesWhenForbiddenPrefixPresentAndPostfixIncorrect.php
+++ b/tests/_data/Common/Method/ExistsPostfixRuleTest/testRuleAppliesWhenForbiddenPrefixPresentAndPostfixIncorrect.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace ArchitectureSnifferTest\Common\ExistsPostfixRuleTest;
+
+class Foo
+{
+    /**
+     * @return bool
+     */
+    public function isSomethingExistWithSomething(): bool
+    {
+    }
+}

--- a/tests/_data/Common/Method/ExistsPostfixRuleTest/testRuleDoesNotApplyWhenClassIsDeprecated.php
+++ b/tests/_data/Common/Method/ExistsPostfixRuleTest/testRuleDoesNotApplyWhenClassIsDeprecated.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace ArchitectureSnifferTest\Common\ExistsPostfixRuleTest;
+
+/**
+ * @deprecated
+ */
+class Foo
+{
+    /**
+     * @return bool
+     */
+    public function isSomethingExistsWithSomething(): bool
+    {
+    }
+}

--- a/tests/_data/Common/Method/ExistsPostfixRuleTest/testRuleDoesNotApplyWhenMethodIsDeprecated.php
+++ b/tests/_data/Common/Method/ExistsPostfixRuleTest/testRuleDoesNotApplyWhenMethodIsDeprecated.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace ArchitectureSnifferTest\Common\ExistsPostfixRuleTest;
+
+class Foo
+{
+    /**
+     * @deprecated
+     *
+     * @return bool
+     */
+    public function isSomethingExistsWithSomething(): bool
+    {
+    }
+}

--- a/tests/_data/Common/Method/ExistsPostfixRuleTest/testRuleDoesNotApplyWhenPostfixCorrect.php
+++ b/tests/_data/Common/Method/ExistsPostfixRuleTest/testRuleDoesNotApplyWhenPostfixCorrect.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace ArchitectureSnifferTest\Common\ExistsPostfixRuleTest;
+
+class Foo
+{
+    /**
+     * @return bool
+     */
+    public function somethingExists(): bool
+    {
+    }
+}

--- a/tests/_data/Common/Method/ExistsPostfixRuleTest/testRuleDoesNotApplyWhenWordExistingUsed.php
+++ b/tests/_data/Common/Method/ExistsPostfixRuleTest/testRuleDoesNotApplyWhenWordExistingUsed.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace ArchitectureSnifferTest\Common\ExistsPostfixRuleTest;
+
+class Foo
+{
+    /**
+     * @return bool
+     */
+    public function isExistingEntitiesProcessed(): bool
+    {
+    }
+}

--- a/tests/_data/Common/Method/ExistsPostfixRuleTest/testRuleDoesNotApplyWithoutForbiddenPrefix.php
+++ b/tests/_data/Common/Method/ExistsPostfixRuleTest/testRuleDoesNotApplyWithoutForbiddenPrefix.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace ArchitectureSnifferTest\Common\ExistsPostfixRuleTest;
+
+class Foo
+{
+    /**
+     * @return bool
+     */
+    public function somethingExistAndNotEmpty(): bool
+    {
+    }
+}

--- a/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleAppliesWhenBoolReturnTypeSpecified.php
+++ b/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleAppliesWhenBoolReturnTypeSpecified.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace ArchitectureSnifferTest\Common\GetReturnTypeTest;
+
+class Foo
+{
+    /**
+     * @return bool
+     */
+    public function getBool(): bool
+    {
+    }
+}

--- a/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleAppliesWhenBoolReturnTypeSpecified.php
+++ b/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleAppliesWhenBoolReturnTypeSpecified.php
@@ -10,6 +10,8 @@ namespace ArchitectureSnifferTest\Common\GetReturnTypeTest;
 class Foo
 {
     /**
+     * @api
+     *
      * @return bool
      */
     public function getBool(): bool

--- a/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleAppliesWhenBoolReturnTypeSpecifiedInPhpDoc.php
+++ b/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleAppliesWhenBoolReturnTypeSpecifiedInPhpDoc.php
@@ -10,6 +10,8 @@ namespace ArchitectureSnifferTest\Common\GetReturnTypeTest;
 class Foo
 {
     /**
+     * @api
+     *
      * @return bool
      */
     public function getBool()

--- a/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleAppliesWhenBoolReturnTypeSpecifiedInPhpDoc.php
+++ b/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleAppliesWhenBoolReturnTypeSpecifiedInPhpDoc.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace ArchitectureSnifferTest\Common\GetReturnTypeTest;
+
+class Foo
+{
+    /**
+     * @return bool
+     */
+    public function getBool()
+    {
+    }
+}

--- a/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleAppliesWhenReturnTypeNotSpecified.php
+++ b/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleAppliesWhenReturnTypeNotSpecified.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace ArchitectureSnifferTest\Common\GetReturnTypeTest;
+
+class Foo
+{
+    public function getSomething()
+    {
+    }
+}

--- a/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleAppliesWhenReturnTypeNotSpecified.php
+++ b/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleAppliesWhenReturnTypeNotSpecified.php
@@ -9,6 +9,9 @@ namespace ArchitectureSnifferTest\Common\GetReturnTypeTest;
 
 class Foo
 {
+    /**
+     * @api
+     */
     public function getSomething()
     {
     }

--- a/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleAppliesWhenVoidReturnTypeSpecified.php
+++ b/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleAppliesWhenVoidReturnTypeSpecified.php
@@ -10,6 +10,8 @@ namespace ArchitectureSnifferTest\Common\GetReturnTypeTest;
 class Foo
 {
     /**
+     * @api
+     *
      * @return void
      */
     public function getVoid(): void

--- a/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleAppliesWhenVoidReturnTypeSpecified.php
+++ b/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleAppliesWhenVoidReturnTypeSpecified.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace ArchitectureSnifferTest\Common\GetReturnTypeTest;
+
+class Foo
+{
+    /**
+     * @return void
+     */
+    public function getVoid(): void
+    {
+    }
+}

--- a/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenApiTagDoesNotExist.php
+++ b/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenApiTagDoesNotExist.php
@@ -10,11 +10,9 @@ namespace ArchitectureSnifferTest\Common\GetReturnTypeTest;
 class Foo
 {
     /**
-     * @api
-     *
-     * @return \stdClass
+     * @return bool
      */
-    public function getStdClass(): \stdClass
+    public function getBool(): bool
     {
     }
 }

--- a/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenBoolReturnTypeSpecifiedForNotGetter.php
+++ b/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenBoolReturnTypeSpecifiedForNotGetter.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace ArchitectureSnifferTest\Common\GetReturnTypeTest;
+
+class Foo
+{
+    /**
+     * @return bool
+     */
+    public function isBool(): bool
+    {
+    }
+}

--- a/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenBoolReturnTypeSpecifiedForNotGetter.php
+++ b/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenBoolReturnTypeSpecifiedForNotGetter.php
@@ -10,6 +10,8 @@ namespace ArchitectureSnifferTest\Common\GetReturnTypeTest;
 class Foo
 {
     /**
+     * @api
+     *
      * @return bool
      */
     public function isBool(): bool

--- a/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenClassIsDeprecated.php
+++ b/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenClassIsDeprecated.php
@@ -13,6 +13,8 @@ namespace ArchitectureSnifferTest\Common\GetReturnTypeTest;
 class Foo
 {
     /**
+     * @api
+     *
      * @return bool
      */
     public function getBool(): bool

--- a/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenClassIsDeprecated.php
+++ b/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenClassIsDeprecated.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace ArchitectureSnifferTest\Common\GetReturnTypeTest;
+
+/**
+ * @deprecated
+ */
+class Foo
+{
+    /**
+     * @return bool
+     */
+    public function getBool(): bool
+    {
+    }
+}

--- a/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenClassReturnTypeSpecified.php
+++ b/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenClassReturnTypeSpecified.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace ArchitectureSnifferTest\Common\GetReturnTypeTest;
+
+class Foo
+{
+    /**
+     * @return \stdClass
+     */
+    public function getStdClass(): \stdClass
+    {
+    }
+}

--- a/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenClassReturnTypeSpecifiedInPhpDoc.php
+++ b/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenClassReturnTypeSpecifiedInPhpDoc.php
@@ -10,6 +10,8 @@ namespace ArchitectureSnifferTest\Common\GetReturnTypeTest;
 class Foo
 {
     /**
+     * @api
+     *
      * @return \stdClass
      */
     public function getStdClass()

--- a/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenClassReturnTypeSpecifiedInPhpDoc.php
+++ b/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenClassReturnTypeSpecifiedInPhpDoc.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace ArchitectureSnifferTest\Common\GetReturnTypeTest;
+
+class Foo
+{
+    /**
+     * @return \stdClass
+     */
+    public function getStdClass()
+    {
+    }
+}

--- a/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenInheritDocBlockExists.php
+++ b/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenInheritDocBlockExists.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace ArchitectureSnifferTest\Common\GetReturnTypeTest;
+
+class Foo
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getSomething()
+    {
+    }
+}

--- a/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenInheritDocTagExists.php
+++ b/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenInheritDocTagExists.php
@@ -10,6 +10,8 @@ namespace ArchitectureSnifferTest\Common\GetReturnTypeTest;
 class Foo
 {
     /**
+     * @api
+     *
      * {@inheritdoc}
      */
     public function getSomething()

--- a/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenMethodIsDeprecated.php
+++ b/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenMethodIsDeprecated.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace ArchitectureSnifferTest\Common\GetReturnTypeTest;
+
+class Foo
+{
+    /**
+     * @deprecated
+     *
+     * @return bool
+     */
+    public function getBool(): bool
+    {
+    }
+}

--- a/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenMethodIsDeprecated.php
+++ b/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenMethodIsDeprecated.php
@@ -10,6 +10,8 @@ namespace ArchitectureSnifferTest\Common\GetReturnTypeTest;
 class Foo
 {
     /**
+     * @api
+     *
      * @deprecated
      *
      * @return bool

--- a/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenMethodNameHasPostfixStatus.php
+++ b/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenMethodNameHasPostfixStatus.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace ArchitectureSnifferTest\Common\GetReturnTypeTest;
+
+class Foo
+{
+    /**
+     * @return bool
+     */
+    public function getEventBehaviorTriggeringStatus(): bool
+    {
+    }
+}

--- a/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenMethodNameHasPostfixStatus.php
+++ b/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenMethodNameHasPostfixStatus.php
@@ -10,6 +10,8 @@ namespace ArchitectureSnifferTest\Common\GetReturnTypeTest;
 class Foo
 {
     /**
+     * @api
+     *
      * @return bool
      */
     public function getEventBehaviorTriggeringStatus(): bool

--- a/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenMixedReturnTypeSpecified.php
+++ b/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenMixedReturnTypeSpecified.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace ArchitectureSnifferTest\Common\GetReturnTypeTest;
+
+class Foo
+{
+    /**
+     * @return mixed
+     */
+    public function getMixed()
+    {
+    }
+}

--- a/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenMixedReturnTypeSpecified.php
+++ b/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenMixedReturnTypeSpecified.php
@@ -10,6 +10,8 @@ namespace ArchitectureSnifferTest\Common\GetReturnTypeTest;
 class Foo
 {
     /**
+     * @api
+     *
      * @return mixed
      */
     public function getMixed()

--- a/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenNotBoolScalarReturnTypeSpecified.php
+++ b/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenNotBoolScalarReturnTypeSpecified.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace ArchitectureSnifferTest\Common\GetReturnTypeTest;
+
+class Foo
+{
+    /**
+     * @return int
+     */
+    public function getInt(): int
+    {
+    }
+}

--- a/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenNotBoolScalarReturnTypeSpecified.php
+++ b/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenNotBoolScalarReturnTypeSpecified.php
@@ -10,6 +10,8 @@ namespace ArchitectureSnifferTest\Common\GetReturnTypeTest;
 class Foo
 {
     /**
+     * @api
+     *
      * @return int
      */
     public function getInt(): int

--- a/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenNotBoolScalarReturnTypeSpecifiedInPhpDoc.php
+++ b/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenNotBoolScalarReturnTypeSpecifiedInPhpDoc.php
@@ -10,6 +10,8 @@ namespace ArchitectureSnifferTest\Common\GetReturnTypeTest;
 class Foo
 {
     /**
+     * @api
+     *
      * @return string
      */
     public function getString()

--- a/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenNotBoolScalarReturnTypeSpecifiedInPhpDoc.php
+++ b/tests/_data/Common/Method/GetterReturnTypeRuleTest/testRuleDoesNotApplyWhenNotBoolScalarReturnTypeSpecifiedInPhpDoc.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace ArchitectureSnifferTest\Common\GetReturnTypeTest;
+
+class Foo
+{
+    /**
+     * @return string
+     */
+    public function getString()
+    {
+    }
+}


### PR DESCRIPTION
- Developer(s): @dmytro-dymarchuk 

- Ticket: https://spryker.atlassian.net/browse/TE-10470

- Release Group: https://release.spryker.com/release-groups/view/3940

- merge: merge

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   ArchitectureSniffer   | patch (currently 0.x)  |                       |

-----------------------------------------

#### Module ArchitectureSniffer

##### Change log

### Fixes

### Improvements

- Introduced `GetterReturnTypeRule` to check return types of methods with prefix `get`. They must not be bool.
- Introduced `ExistsPostfixRule` to check if methods with postfix `Exist` meet naming conventions. They must not start with the prefix `is`.
