### PR TITLE
TE-10615 Skipped checks for deprecated methods and class

### DIFF
--- a/src/Client/ClientInterfaceRule.php
+++ b/src/Client/ClientInterfaceRule.php
@@ -13,7 +13,12 @@ use PHPMD\Rule\InterfaceAware;
 class ClientInterfaceRule extends ApiInterfaceRule implements InterfaceAware
 {
     /**
-     * @var string
+     * @phpstan-return non-empty-string
+     *
+     * @return string
      */
-    protected $classRegex = '(\\\\Client\\\\[A-Za-z]+\\\\[A-Za-z]+ClientInterface$)';
+    protected function getClassRegex(): string
+    {
+        return '(\\\\Client\\\\[A-Za-z]+\\\\[A-Za-z]+ClientInterface$)';
+    }
 }

--- a/src/Client/ClientRule.php
+++ b/src/Client/ClientRule.php
@@ -13,7 +13,12 @@ use PHPMD\Rule\ClassAware;
 class ClientRule extends ImplementsApiInterfaceRule implements ClassAware
 {
     /**
-     * @var string
+     * @phpstan-return non-empty-string
+     *
+     * @return string
      */
-    protected $classRegex = '(\\\\Client\\\\[A-Za-z]+\\\\[A-Za-z]+Client$)';
+    protected function getClassRegex(): string
+    {
+        return '(\\\\Client\\\\[A-Za-z]+\\\\[A-Za-z]+Client$)';
+    }
 }

--- a/src/Common/ApiInterfaceRule.php
+++ b/src/Common/ApiInterfaceRule.php
@@ -12,17 +12,12 @@ use PHPMD\AbstractNode;
 use PHPMD\Node\MethodNode;
 use PHPMD\Rule\InterfaceAware;
 
-class ApiInterfaceRule extends SprykerAbstractRule implements InterfaceAware
+abstract class ApiInterfaceRule extends SprykerAbstractRule implements InterfaceAware
 {
     /**
      * @var string
      */
     public const RULE = 'Every method must also contain the @api tag in docblock and a contract text above.';
-
-    /**
-     * @var string
-     */
-    protected $classRegex = '';
 
     /**
      * @var array
@@ -44,7 +39,7 @@ class ApiInterfaceRule extends SprykerAbstractRule implements InterfaceAware
      */
     public function apply(AbstractNode $node)
     {
-        if (empty($this->classRegex) || preg_match($this->classRegex, $node->getFullQualifiedName()) === 0) {
+        if (preg_match($this->getClassRegex(), $node->getFullQualifiedName()) === 0) {
             return;
         }
 
@@ -105,4 +100,11 @@ class ApiInterfaceRule extends SprykerAbstractRule implements InterfaceAware
             ],
         );
     }
+
+    /**
+     * @phpstan-return non-empty-string
+     *
+     * @return string
+     */
+    abstract protected function getClassRegex(): string;
 }

--- a/src/Common/EnforceAbstractionInConstructor.php
+++ b/src/Common/EnforceAbstractionInConstructor.php
@@ -59,7 +59,7 @@ class EnforceAbstractionInConstructor extends AbstractRule implements ClassAware
     protected function checkParameter(ASTParameter $param, AbstractNode $node)
     {
         $class = $param->getClass();
-        if (empty($class) || $class->isAbstract()) {
+        if ($class === null || $class->isAbstract()) {
             return;
         }
 

--- a/src/Common/ImplementsApiInterfaceRule.php
+++ b/src/Common/ImplementsApiInterfaceRule.php
@@ -52,7 +52,7 @@ abstract class ImplementsApiInterfaceRule extends SprykerAbstractRule implements
             return false;
         }
 
-        if (empty($this->classRegex) || preg_match($this->classRegex, $node->getFullQualifiedName()) === 0) {
+        if (preg_match($this->getClassRegex(), $node->getFullQualifiedName()) === 0) {
             return false;
         }
 

--- a/src/Common/ImplementsApiInterfaceRule.php
+++ b/src/Common/ImplementsApiInterfaceRule.php
@@ -12,17 +12,12 @@ use PHPMD\AbstractNode;
 use PHPMD\Node\ClassNode;
 use PHPMD\Rule\ClassAware;
 
-class ImplementsApiInterfaceRule extends SprykerAbstractRule implements ClassAware
+abstract class ImplementsApiInterfaceRule extends SprykerAbstractRule implements ClassAware
 {
     /**
      * @var string
      */
     public const RULE = 'Must implement an interface with same name and suffix \'Interface\'.';
-
-    /**
-     * @var string
-     */
-    protected $classRegex = '';
 
     /**
      * @return string
@@ -91,4 +86,11 @@ class ImplementsApiInterfaceRule extends SprykerAbstractRule implements ClassAwa
             ],
         );
     }
+
+    /**
+     * @phpstan-return non-empty-string
+     *
+     * @return string
+     */
+    abstract protected function getClassRegex(): string;
 }

--- a/src/Common/LayerAccessRule.php
+++ b/src/Common/LayerAccessRule.php
@@ -14,6 +14,8 @@ use PHPMD\Rule\ClassAware;
 
 class LayerAccessRule extends AbstractRule implements ClassAware
 {
+    use DeprecationTrait;
+
     /**
      * @return string
      */
@@ -105,6 +107,10 @@ class LayerAccessRule extends AbstractRule implements ClassAware
      */
     public function apply(AbstractNode $node)
     {
+        if ($this->isClassDeprecated($node)) {
+            return;
+        }
+
         $patterns = $this->collectPatterns($node);
 
         $this->applyPatterns($node, $patterns);

--- a/src/Service/ServiceInterfaceRule.php
+++ b/src/Service/ServiceInterfaceRule.php
@@ -13,7 +13,12 @@ use PHPMD\Rule\InterfaceAware;
 class ServiceInterfaceRule extends ApiInterfaceRule implements InterfaceAware
 {
     /**
-     * @var string
+     * @phpstan-return non-empty-string
+     *
+     * @return string
      */
-    protected $classRegex = '(\\\\Service\\\\.+ServiceInterface$)';
+    protected function getClassRegex(): string
+    {
+        return '(\\\\Service\\\\.+ServiceInterface$)';
+    }
 }

--- a/src/Service/ServiceRule.php
+++ b/src/Service/ServiceRule.php
@@ -14,11 +14,6 @@ use PHPMD\Rule\ClassAware;
 class ServiceRule extends ImplementsApiInterfaceRule implements ClassAware
 {
     /**
-     * @var string
-     */
-    protected $classRegex = '(\\\\Service\\\\.+Service$)';
-
-    /**
      * @param \PHPMD\AbstractNode $node
      *
      * @return bool
@@ -26,5 +21,15 @@ class ServiceRule extends ImplementsApiInterfaceRule implements ClassAware
     protected function isApplicable(AbstractNode $node): bool
     {
         return $node->getName() !== 'AbstractService' && parent::isApplicable($node);
+    }
+
+    /**
+     * @phpstan-return non-empty-string
+     *
+     * @return string
+     */
+    protected function getClassRegex(): string
+    {
+        return '(\\\\Client\\\\[A-Za-z]+\\\\[A-Za-z]+Client$)';
     }
 }

--- a/src/Zed/Business/Directory/DirectoryNoModelRule.php
+++ b/src/Zed/Business/Directory/DirectoryNoModelRule.php
@@ -7,12 +7,15 @@
 
 namespace ArchitectureSniffer\Zed\Business\Directory;
 
+use ArchitectureSniffer\Common\DeprecationTrait;
 use PHPMD\AbstractNode;
 use PHPMD\Node\ClassNode;
 use PHPMD\Rule\ClassAware;
 
 class DirectoryNoModelRule extends AbstractDirectoryRule implements ClassAware
 {
+    use DeprecationTrait;
+
     /**
      * @var string
      */
@@ -47,7 +50,9 @@ class DirectoryNoModelRule extends AbstractDirectoryRule implements ClassAware
      */
     protected function applyRule(ClassNode $classNode)
     {
-        if (!preg_match('/Business\\\\Model\\\\/', $classNode->getFullQualifiedName())) {
+        if (
+            $this->isClassDeprecated($classNode)
+            || !preg_match('/Business\\\\Model\\\\/', $classNode->getFullQualifiedName())) {
             return;
         }
 

--- a/src/Zed/Business/Directory/DirectoryNoModelRule.php
+++ b/src/Zed/Business/Directory/DirectoryNoModelRule.php
@@ -52,7 +52,8 @@ class DirectoryNoModelRule extends AbstractDirectoryRule implements ClassAware
     {
         if (
             $this->isClassDeprecated($classNode)
-            || !preg_match('/Business\\\\Model\\\\/', $classNode->getFullQualifiedName())) {
+            || !preg_match('/Business\\\\Model\\\\/', $classNode->getFullQualifiedName())
+        ) {
             return;
         }
 

--- a/src/Zed/Business/Facade/AbstractFacadeRule.php
+++ b/src/Zed/Business/Facade/AbstractFacadeRule.php
@@ -9,6 +9,7 @@ namespace ArchitectureSniffer\Zed\Business\Facade;
 
 use PHPMD\AbstractRule;
 use PHPMD\Node\AbstractNode;
+use PHPMD\Node\ClassNode;
 use PHPMD\Node\MethodNode;
 
 abstract class AbstractFacadeRule extends AbstractRule
@@ -39,7 +40,7 @@ abstract class AbstractFacadeRule extends AbstractRule
      *
      * @return bool
      */
-    protected function isAbstractFacade(AbstractNode $node): bool
+    protected function isAbstractFacade(ClassNode $node): bool
     {
         return $node->getName() === 'AbstractFacade';
     }

--- a/src/Zed/Business/Facade/AllMethodsPublicInFacadeRule.php
+++ b/src/Zed/Business/Facade/AllMethodsPublicInFacadeRule.php
@@ -37,6 +37,10 @@ class AllMethodsPublicInFacadeRule extends AbstractFacadeRule implements ClassAw
      */
     public function apply(AbstractNode $node)
     {
+        if (!$node instanceof ClassNode) {
+            return;
+        }
+
         if (!$this->isFacade($node) || $this->isAbstractFacade($node)) {
             return;
         }

--- a/src/Zed/Business/Facade/AllMethodsPublicInFacadeRule.php
+++ b/src/Zed/Business/Facade/AllMethodsPublicInFacadeRule.php
@@ -7,6 +7,7 @@
 
 namespace ArchitectureSniffer\Zed\Business\Facade;
 
+use ArchitectureSniffer\Common\DeprecationTrait;
 use PHPMD\AbstractNode;
 use PHPMD\Node\ClassNode;
 use PHPMD\Node\MethodNode;
@@ -14,6 +15,8 @@ use PHPMD\Rule\ClassAware;
 
 class AllMethodsPublicInFacadeRule extends AbstractFacadeRule implements ClassAware
 {
+    use DeprecationTrait;
+
     /**
      * @var string
      */
@@ -49,6 +52,11 @@ class AllMethodsPublicInFacadeRule extends AbstractFacadeRule implements ClassAw
     protected function applyRule(ClassNode $node)
     {
         foreach ($node->getMethods() as $method) {
+            if ($this->isMethodDeprecated($method)) {
+                continue;
+            }
+
+
             $this->checkVisibility($method);
         }
     }

--- a/src/Zed/Business/Facade/AllMethodsPublicInFacadeRule.php
+++ b/src/Zed/Business/Facade/AllMethodsPublicInFacadeRule.php
@@ -56,7 +56,6 @@ class AllMethodsPublicInFacadeRule extends AbstractFacadeRule implements ClassAw
                 continue;
             }
 
-
             $this->checkVisibility($method);
         }
     }

--- a/src/Zed/Business/Facade/FacadeArgumentsNotAllowedUseEntityTransferRule.php
+++ b/src/Zed/Business/Facade/FacadeArgumentsNotAllowedUseEntityTransferRule.php
@@ -7,6 +7,7 @@
 
 namespace ArchitectureSniffer\Zed\Business\Facade;
 
+use ArchitectureSniffer\Common\DeprecationTrait;
 use PDepend\Source\AST\AbstractASTClassOrInterface;
 use PDepend\Source\AST\ASTParameter;
 use PHPMD\AbstractNode;
@@ -15,6 +16,8 @@ use PHPMD\Rule\MethodAware;
 
 class FacadeArgumentsNotAllowedUseEntityTransferRule extends AbstractFacadeRule implements MethodAware
 {
+    use DeprecationTrait;
+
     /**
      * @var string
      */
@@ -59,6 +62,10 @@ class FacadeArgumentsNotAllowedUseEntityTransferRule extends AbstractFacadeRule 
      */
     protected function applyRule(MethodNode $method): void
     {
+        if ($this->isMethodDeprecated($method)) {
+            return;
+        }
+
         $params = $method->getParameters();
 
         foreach ($params as $param) {

--- a/src/Zed/Business/Facade/FacadeArgumentsNotAllowedUseEntityTransferRule.php
+++ b/src/Zed/Business/Facade/FacadeArgumentsNotAllowedUseEntityTransferRule.php
@@ -83,7 +83,7 @@ class FacadeArgumentsNotAllowedUseEntityTransferRule extends AbstractFacadeRule 
     {
         $class = $param->getClass();
 
-        if (empty($class) || !$this->isArgumentEntityTransfer($class)) {
+        if ($class === null || !$this->isArgumentEntityTransfer($class)) {
             return;
         }
 

--- a/src/Zed/Business/Facade/FacadeArgumentsRule.php
+++ b/src/Zed/Business/Facade/FacadeArgumentsRule.php
@@ -51,7 +51,9 @@ class FacadeArgumentsRule extends AbstractFacadeRule implements MethodAware
      */
     protected function applyRule(MethodNode $method)
     {
-        if ($this->isMethodDeprecated($method))
+        if ($this->isMethodDeprecated($method)) {
+            return;
+        }
 
         $params = $method->getParameters();
         foreach ($params as $param) {
@@ -68,7 +70,7 @@ class FacadeArgumentsRule extends AbstractFacadeRule implements MethodAware
     protected function checkParameter(ASTParameter $param, AbstractNode $node)
     {
         $class = $param->getClass();
-        if (empty($class) || $class->getNamespaceName() === 'Generated\Shared\Transfer') {
+        if ($class === null || $class->getNamespaceName() === 'Generated\Shared\Transfer') {
             return;
         }
 

--- a/src/Zed/Business/Facade/FacadeArgumentsRule.php
+++ b/src/Zed/Business/Facade/FacadeArgumentsRule.php
@@ -7,6 +7,7 @@
 
 namespace ArchitectureSniffer\Zed\Business\Facade;
 
+use ArchitectureSniffer\Common\DeprecationTrait;
 use PDepend\Source\AST\ASTParameter;
 use PHPMD\AbstractNode;
 use PHPMD\Node\MethodNode;
@@ -14,6 +15,8 @@ use PHPMD\Rule\MethodAware;
 
 class FacadeArgumentsRule extends AbstractFacadeRule implements MethodAware
 {
+    use DeprecationTrait;
+
     /**
      * @var string
      */
@@ -48,6 +51,8 @@ class FacadeArgumentsRule extends AbstractFacadeRule implements MethodAware
      */
     protected function applyRule(MethodNode $method)
     {
+        if ($this->isMethodDeprecated($method))
+
         $params = $method->getParameters();
         foreach ($params as $param) {
             $this->checkParameter($param, $method);

--- a/src/Zed/Business/Facade/FacadeNoLogicRule.php
+++ b/src/Zed/Business/Facade/FacadeNoLogicRule.php
@@ -7,6 +7,7 @@
 
 namespace ArchitectureSniffer\Zed\Business\Facade;
 
+use ArchitectureSniffer\Common\DeprecationTrait;
 use PHPMD\AbstractNode;
 use PHPMD\Node\ClassNode;
 use PHPMD\Node\MethodNode;
@@ -14,6 +15,8 @@ use PHPMD\Rule\ClassAware;
 
 class FacadeNoLogicRule extends AbstractFacadeRule implements ClassAware
 {
+    use DeprecationTrait;
+
     /**
      * @var string
      */
@@ -60,6 +63,10 @@ class FacadeNoLogicRule extends AbstractFacadeRule implements ClassAware
     protected function applyRule(ClassNode $node)
     {
         foreach ($node->getMethods() as $method) {
+            if ($this->isMethodDeprecated($method)) {
+                return;
+            }
+
             $this->checkStatements($method);
         }
     }

--- a/src/Zed/Business/Facade/FacadeReturnValueRule.php
+++ b/src/Zed/Business/Facade/FacadeReturnValueRule.php
@@ -7,12 +7,15 @@
 
 namespace ArchitectureSniffer\Zed\Business\Facade;
 
+use ArchitectureSniffer\Common\DeprecationTrait;
 use PHPMD\AbstractNode;
 use PHPMD\Node\MethodNode;
 use PHPMD\Rule\MethodAware;
 
 class FacadeReturnValueRule extends AbstractFacadeRule implements MethodAware
 {
+    use DeprecationTrait;
+
     /**
      * @var string
      */
@@ -57,6 +60,10 @@ class FacadeReturnValueRule extends AbstractFacadeRule implements MethodAware
      */
     protected function applyRule(MethodNode $node)
     {
+        if ($this->isMethodDeprecated($node)) {
+            return;
+        }
+
         $comment = $node->getComment();
         if ($this->hasInvalidReturnType($comment)) {
             $message = sprintf(

--- a/src/Zed/Business/Facade/FacadeRule.php
+++ b/src/Zed/Business/Facade/FacadeRule.php
@@ -7,6 +7,7 @@
 
 namespace ArchitectureSniffer\Zed\Business\Facade;
 
+use ArchitectureSniffer\Common\DeprecationTrait;
 use PHPMD\AbstractNode;
 use PHPMD\Node\ClassNode;
 use PHPMD\Node\MethodNode;
@@ -14,6 +15,8 @@ use PHPMD\Rule\ClassAware;
 
 class FacadeRule extends AbstractFacadeRule implements ClassAware
 {
+    use DeprecationTrait;
+
     /**
      * @var string
      */
@@ -41,6 +44,10 @@ class FacadeRule extends AbstractFacadeRule implements ClassAware
         $this->applyStatelessThereAreNoProperties($node);
 
         foreach ($node->getMethods() as $method) {
+            if ($this->isMethodDeprecated($method)) {
+                continue;
+            }
+
             $this->applyNoInstantiationsWithNew($method);
         }
     }

--- a/src/Zed/Business/Facade/FacadeSingleFactoryCallRule.php
+++ b/src/Zed/Business/Facade/FacadeSingleFactoryCallRule.php
@@ -7,6 +7,7 @@
 
 namespace ArchitectureSniffer\Zed\Business\Facade;
 
+use ArchitectureSniffer\Common\DeprecationTrait;
 use PHPMD\AbstractNode;
 use PHPMD\Node\ClassNode;
 use PHPMD\Node\MethodNode;
@@ -14,6 +15,8 @@ use PHPMD\Rule\ClassAware;
 
 class FacadeSingleFactoryCallRule extends AbstractFacadeRule implements ClassAware
 {
+    use DeprecationTrait;
+
     /**
      * @var string
      */
@@ -64,6 +67,10 @@ class FacadeSingleFactoryCallRule extends AbstractFacadeRule implements ClassAwa
     protected function applyRule(ClassNode $node)
     {
         foreach ($node->getMethods() as $method) {
+            if ($this->isMethodDeprecated($method)) {
+                continue;
+            }
+
             $this->checkStatements($method);
         }
     }

--- a/src/Zed/Communication/Plugin/PluginArgumentsNotAllowedUseEntityTransferRule.php
+++ b/src/Zed/Communication/Plugin/PluginArgumentsNotAllowedUseEntityTransferRule.php
@@ -7,6 +7,7 @@
 
 namespace ArchitectureSniffer\Zed\Communication\Plugin;
 
+use ArchitectureSniffer\Common\DeprecationTrait;
 use ArchitectureSniffer\Common\Plugin\AbstractPluginRule;
 use PDepend\Source\AST\AbstractASTClassOrInterface;
 use PDepend\Source\AST\ASTParameter;
@@ -16,6 +17,8 @@ use PHPMD\Rule\ClassAware;
 
 class PluginArgumentsNotAllowedUseEntityTransferRule extends AbstractPluginRule implements ClassAware
 {
+    use DeprecationTrait;
+
     /**
      * @var string
      */
@@ -46,7 +49,7 @@ class PluginArgumentsNotAllowedUseEntityTransferRule extends AbstractPluginRule 
      */
     public function apply(AbstractNode $node): void
     {
-        if (!$this->isPlugin($node)) {
+        if (!$this->isPlugin($node) || $this->isClassDeprecated($node)) {
             return;
         }
 

--- a/src/Zed/Communication/Plugin/PluginArgumentsNotAllowedUseEntityTransferRule.php
+++ b/src/Zed/Communication/Plugin/PluginArgumentsNotAllowedUseEntityTransferRule.php
@@ -84,7 +84,7 @@ class PluginArgumentsNotAllowedUseEntityTransferRule extends AbstractPluginRule 
     {
         $class = $param->getClass();
 
-        if (empty($class) || !$this->isArgumentEntityTransfer($class)) {
+        if ($class === null || !$this->isArgumentEntityTransfer($class)) {
             return;
         }
 

--- a/src/Zed/Persistence/SpyEntityUsageRule.php
+++ b/src/Zed/Persistence/SpyEntityUsageRule.php
@@ -7,12 +7,15 @@
 
 namespace ArchitectureSniffer\Zed\Persistence;
 
+use ArchitectureSniffer\Common\DeprecationTrait;
 use PHPMD\AbstractNode;
 use PHPMD\Node\ClassNode;
 use PHPMD\Rule\ClassAware;
 
 class SpyEntityUsageRule extends AbstractPersistenceRule implements ClassAware
 {
+    use DeprecationTrait;
+
     /**
      * @var string
      */
@@ -35,6 +38,10 @@ class SpyEntityUsageRule extends AbstractPersistenceRule implements ClassAware
         }
 
         if ($this->isExcludedModule($node)) {
+            return;
+        }
+
+        if ($this->isClassDeprecated($node)) {
             return;
         }
 

--- a/tests/Zed/Business/AllMethodsPublicInFacadeRuleTest.php
+++ b/tests/Zed/Business/AllMethodsPublicInFacadeRuleTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace ArchitectureSnifferTest\Zed\Business;
+
+use ArchitectureSniffer\Zed\Business\Facade\AllMethodsPublicInFacadeRule;
+use ArchitectureSnifferTest\AbstractArchitectureSnifferRuleTest;
+
+class AllMethodsPublicInFacadeRuleTest extends AbstractArchitectureSnifferRuleTest
+{
+    /**
+     * @return void
+     */
+    public function testRuleDoesNotApplyForDeprecatedMethod(): void
+    {
+        $pluginSuffixRule = new AllMethodsPublicInFacadeRule();
+        $pluginSuffixRule->setReport($this->getReportMock(0));
+        $pluginSuffixRule->apply($this->getClassNode());
+    }
+
+    /**
+     * @return void
+     */
+    public function testRuleDoesNotApplyForAbstractFacade(): void
+    {
+        $pluginSuffixRule = new AllMethodsPublicInFacadeRule();
+        $pluginSuffixRule->setReport($this->getReportMock(0));
+        $pluginSuffixRule->apply($this->getClassNode());
+    }
+
+    /**
+     * @return void
+     */
+    public function testRuleDoesNotApplyForPublicMethod(): void
+    {
+        $pluginSuffixRule = new AllMethodsPublicInFacadeRule();
+        $pluginSuffixRule->setReport($this->getReportMock(0));
+        $pluginSuffixRule->apply($this->getClassNode());
+    }
+
+    /**
+     * @return void
+     */
+    public function testRuleDoesNotApplyForNotFacadeMethod(): void
+    {
+        $pluginSuffixRule = new AllMethodsPublicInFacadeRule();
+        $pluginSuffixRule->setReport($this->getReportMock(0));
+        $pluginSuffixRule->apply($this->getClassNode());
+    }
+
+    /**
+     * @return void
+     */
+    public function testRuleApplyForProtectedMethod(): void
+    {
+        $pluginSuffixRule = new AllMethodsPublicInFacadeRule();
+        $pluginSuffixRule->setReport($this->getReportMock(1));
+        $pluginSuffixRule->apply($this->getClassNode());
+    }
+
+    /**
+     * @return void
+     */
+    public function testRuleApplyForPrivateMethod(): void
+    {
+        $pluginSuffixRule = new AllMethodsPublicInFacadeRule();
+        $pluginSuffixRule->setReport($this->getReportMock(1));
+        $pluginSuffixRule->apply($this->getClassNode());
+    }
+}

--- a/tests/Zed/Business/FacadeArgumentsNotAllowedUseEntityTransferRuleTest.php
+++ b/tests/Zed/Business/FacadeArgumentsNotAllowedUseEntityTransferRuleTest.php
@@ -25,6 +25,16 @@ class FacadeArgumentsNotAllowedUseEntityTransferRuleTest extends AbstractArchite
     /**
      * @return void
      */
+    public function testFacadeDeprecatedMethodHasEntityTransferArgument(): void
+    {
+        $pluginSuffixRule = new FacadeArgumentsNotAllowedUseEntityTransferRule();
+        $pluginSuffixRule->setReport($this->getReportMock(0));
+        $pluginSuffixRule->apply($this->getMethodNode());
+    }
+
+    /**
+     * @return void
+     */
     public function testFacadeMethodDoesNotHaveEntityTransferArgument(): void
     {
         $pluginSuffixRule = new FacadeArgumentsNotAllowedUseEntityTransferRule();

--- a/tests/Zed/Persistence/SpyEntityUsageRuleTest.php
+++ b/tests/Zed/Persistence/SpyEntityUsageRuleTest.php
@@ -21,6 +21,15 @@ class SpyEntityUsageRuleTest extends AbstractArchitectureSnifferRuleTest
         $pluginSuffixRule->setReport($this->getReportMock(0));
         $pluginSuffixRule->apply($this->getClassNode());
     }
+    /**
+     * @return void
+     */
+    public function testFacadeCanCreateSpyEntityInDeprecatedMethod(): void
+    {
+        $pluginSuffixRule = new SpyEntityUsageRule();
+        $pluginSuffixRule->setReport($this->getReportMock(0));
+        $pluginSuffixRule->apply($this->getClassNode());
+    }
 
     /**
      * @return void

--- a/tests/Zed/Persistence/SpyEntityUsageRuleTest.php
+++ b/tests/Zed/Persistence/SpyEntityUsageRuleTest.php
@@ -25,6 +25,46 @@ class SpyEntityUsageRuleTest extends AbstractArchitectureSnifferRuleTest
     /**
      * @return void
      */
+    public function testEntityManagerCanCreateSpyEntity(): void
+    {
+        $pluginSuffixRule = new SpyEntityUsageRule();
+        $pluginSuffixRule->setReport($this->getReportMock(0));
+        $pluginSuffixRule->apply($this->getClassNode());
+    }
+
+    /**
+     * @return void
+     */
+    public function testExcludedModuleCanCreateSpyEntity(): void
+    {
+        $pluginSuffixRule = new SpyEntityUsageRule();
+        $pluginSuffixRule->setReport($this->getReportMock(0));
+        $pluginSuffixRule->apply($this->getClassNode());
+    }
+
+    /**
+     * @return void
+     */
+    public function testNotZedLevelCanCreateSpyEntity(): void
+    {
+        $pluginSuffixRule = new SpyEntityUsageRule();
+        $pluginSuffixRule->setReport($this->getReportMock(0));
+        $pluginSuffixRule->apply($this->getClassNode());
+    }
+
+    /**
+     * @return void
+     */
+    public function testDeprecatedClassCanCreateSpyEntity(): void
+    {
+        $pluginSuffixRule = new SpyEntityUsageRule();
+        $pluginSuffixRule->setReport($this->getReportMock(0));
+        $pluginSuffixRule->apply($this->getClassNode());
+    }
+
+    /**
+     * @return void
+     */
     public function testFacadeCanCreateSpyEntityInDeprecatedMethod(): void
     {
         $pluginSuffixRule = new SpyEntityUsageRule();

--- a/tests/Zed/Persistence/SpyEntityUsageRuleTest.php
+++ b/tests/Zed/Persistence/SpyEntityUsageRuleTest.php
@@ -21,6 +21,7 @@ class SpyEntityUsageRuleTest extends AbstractArchitectureSnifferRuleTest
         $pluginSuffixRule->setReport($this->getReportMock(0));
         $pluginSuffixRule->apply($this->getClassNode());
     }
+
     /**
      * @return void
      */

--- a/tests/_data/Zed/Business/AllMethodsPublicInFacadeRuleTest/testRuleApplyForPrivateMethod.php
+++ b/tests/_data/Zed/Business/AllMethodsPublicInFacadeRuleTest/testRuleApplyForPrivateMethod.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spyryker\Zed\Module\Business;
+
+class TestFacade
+{
+    /**
+     * @return void
+     */
+    private function someMethod(): void
+    {
+    }
+}

--- a/tests/_data/Zed/Business/AllMethodsPublicInFacadeRuleTest/testRuleApplyForProtectedMethod.php
+++ b/tests/_data/Zed/Business/AllMethodsPublicInFacadeRuleTest/testRuleApplyForProtectedMethod.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spyryker\Zed\Module\Business;
+
+class TestFacade
+{
+    /**
+     * @return void
+     */
+    protected function someMethod(): void
+    {
+    }
+}

--- a/tests/_data/Zed/Business/AllMethodsPublicInFacadeRuleTest/testRuleDoesNotApplyForAbstractFacade.php
+++ b/tests/_data/Zed/Business/AllMethodsPublicInFacadeRuleTest/testRuleDoesNotApplyForAbstractFacade.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spyryker\Zed\Module\Business;
+
+class AbstractFacade
+{
+    /**
+     * @return void
+     */
+    protected function someMethod(): void
+    {
+    }
+}

--- a/tests/_data/Zed/Business/AllMethodsPublicInFacadeRuleTest/testRuleDoesNotApplyForDeprecatedMethod.php
+++ b/tests/_data/Zed/Business/AllMethodsPublicInFacadeRuleTest/testRuleDoesNotApplyForDeprecatedMethod.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spyryker\Zed\Module\Business;
+
+class TestFacade
+{
+    /**
+     * @deprecated
+     *
+     * @return void
+     */
+    protected function someMethod(): void
+    {
+    }
+}

--- a/tests/_data/Zed/Business/AllMethodsPublicInFacadeRuleTest/testRuleDoesNotApplyForNotFacadeMethod.php
+++ b/tests/_data/Zed/Business/AllMethodsPublicInFacadeRuleTest/testRuleDoesNotApplyForNotFacadeMethod.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spyryker\Zed\Module\Business;
+
+class TestConfig
+{
+    /**
+     * @return void
+     */
+    protected function someMethod(): void
+    {
+    }
+}

--- a/tests/_data/Zed/Business/AllMethodsPublicInFacadeRuleTest/testRuleDoesNotApplyForPublicMethod.php
+++ b/tests/_data/Zed/Business/AllMethodsPublicInFacadeRuleTest/testRuleDoesNotApplyForPublicMethod.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spyryker\Zed\Module\Business;
+
+class TestFacade
+{
+    /**
+     * @return void
+     */
+    public function someMethod(): void
+    {
+    }
+}

--- a/tests/_data/Zed/Business/FacadeArgumentsNotAllowedUseEntityTransferRuleTest/testFacadeDeprecatedMethodHasEntityTransferArgument.php
+++ b/tests/_data/Zed/Business/FacadeArgumentsNotAllowedUseEntityTransferRuleTest/testFacadeDeprecatedMethodHasEntityTransferArgument.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spyryker\Zed\Module\Business;
+
+use Generated\Shared\Transfer\TestModuleEntityTransfer;
+
+class TestFacade
+{
+    /**
+     * @deprecated
+     *
+     * @param \Generated\Shared\Transfer\TestModuleEntityTransfer $testModuleEntityTransfer
+     *
+     * @return void
+     */
+    protected function someMethod(TestModuleEntityTransfer $testModuleEntityTransfer): void
+    {
+    }
+}

--- a/tests/_data/Zed/Persistence/SpyEntityUsageRuleTest/testDeprecatedClassCanCreateSpyEntity.php
+++ b/tests/_data/Zed/Persistence/SpyEntityUsageRuleTest/testDeprecatedClassCanCreateSpyEntity.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spyryker\Zed\DataImport\Persistence\EntityManager;
+
+use Orm\Zed\Persistence\SpyTestEntity;
+
+class TestEntityManager
+{
+    /**
+     * @return void
+     */
+    protected function createTestSpyEntity(): void
+    {
+        $spyTestEntity = new SpyTestEntity();
+    }
+}

--- a/tests/_data/Zed/Persistence/SpyEntityUsageRuleTest/testDeprecatedClassCanCreateSpyEntity.php
+++ b/tests/_data/Zed/Persistence/SpyEntityUsageRuleTest/testDeprecatedClassCanCreateSpyEntity.php
@@ -5,11 +5,14 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
-namespace Spyryker\Zed\DataImport\Persistence\EntityManager;
+namespace Spyryker\Zed\Module\Persistence\TestClass;
 
 use Orm\Zed\Persistence\SpyTestEntity;
 
-class TestEntityManager
+/**
+ * @deprecated
+ */
+class TestClass
 {
     /**
      * @return void

--- a/tests/_data/Zed/Persistence/SpyEntityUsageRuleTest/testEntityManagerCanCreateSpyEntity.php
+++ b/tests/_data/Zed/Persistence/SpyEntityUsageRuleTest/testEntityManagerCanCreateSpyEntity.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spyryker\Zed\Module\Persistence\EntityManager;
+
+use Orm\Zed\Persistence\SpyTestEntity;
+
+class TestEntityManager
+{
+    /**
+     * @return void
+     */
+    protected function createTestSpyEntity(): void
+    {
+        $spyTestEntity = new SpyTestEntity();
+    }
+}

--- a/tests/_data/Zed/Persistence/SpyEntityUsageRuleTest/testExcludedModuleCanCreateSpyEntity.php
+++ b/tests/_data/Zed/Persistence/SpyEntityUsageRuleTest/testExcludedModuleCanCreateSpyEntity.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spyryker\Zed\DataImport\Persistence\EntityManager;
+
+use Orm\Zed\Persistence\SpyTestEntity;
+
+class TestEntityManager
+{
+    /**
+     * @return void
+     */
+    protected function createTestSpyEntity(): void
+    {
+        $spyTestEntity = new SpyTestEntity();
+    }
+}

--- a/tests/_data/Zed/Persistence/SpyEntityUsageRuleTest/testExcludedModuleCanCreateSpyEntity.php
+++ b/tests/_data/Zed/Persistence/SpyEntityUsageRuleTest/testExcludedModuleCanCreateSpyEntity.php
@@ -5,11 +5,11 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
-namespace Spyryker\Zed\DataImport\Persistence\EntityManager;
+namespace Spyryker\Zed\DataImport\Persistence\TestClass;
 
 use Orm\Zed\Persistence\SpyTestEntity;
 
-class TestEntityManager
+class TestClass
 {
     /**
      * @return void

--- a/tests/_data/Zed/Persistence/SpyEntityUsageRuleTest/testFacadeCanCreateSpyEntityInDeprecatedMethod.php
+++ b/tests/_data/Zed/Persistence/SpyEntityUsageRuleTest/testFacadeCanCreateSpyEntityInDeprecatedMethod.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spyryker\Zed\Module\Persistence\Repository;
+
+use Orm\Zed\Persistence\SpyTestEntity;
+
+class TestRepository
+{
+    /**
+     * @deprecated
+     *
+     * @return void
+     */
+    protected function createTestSpyEntity(): void
+    {
+        $spyTestEntity = new SpyTestEntity();
+    }
+}

--- a/tests/_data/Zed/Persistence/SpyEntityUsageRuleTest/testNotZedLevelCanCreateSpyEntity.php
+++ b/tests/_data/Zed/Persistence/SpyEntityUsageRuleTest/testNotZedLevelCanCreateSpyEntity.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spyryker\Yves\Module\Persistence\EntityManager;
+
+use Orm\Zed\Persistence\SpyTestEntity;
+
+class TestEntityManager
+{
+    /**
+     * @return void
+     */
+    protected function createTestSpyEntity(): void
+    {
+        $spyTestEntity = new SpyTestEntity();
+    }
+}

--- a/tests/_data/Zed/Persistence/SpyEntityUsageRuleTest/testNotZedLevelCanCreateSpyEntity.php
+++ b/tests/_data/Zed/Persistence/SpyEntityUsageRuleTest/testNotZedLevelCanCreateSpyEntity.php
@@ -5,11 +5,11 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
-namespace Spyryker\Yves\Module\Persistence\EntityManager;
+namespace Spyryker\Yves\Module\Persistence\TestClass;
 
 use Orm\Zed\Persistence\SpyTestEntity;
 
-class TestEntityManager
+class TestClass
 {
     /**
      * @return void


### PR DESCRIPTION
- Developer(s): @dmytro-dymarchuk 

- Ticket: https://spryker.atlassian.net/browse/TE-10615

- Release Group: https://release.spryker.com/release-groups/view/3948

- merge: merge

**We will release this together with the bridge signature fixes.**

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   ArchitectureSniffer   | patch (currently 0.x) {skip}  |                       |

-----------------------------------------

#### Module ArchitectureSniffer

##### Change log

### Fixes

### Improvements

- Adjusted `LayerAccessRule` so it doesn't check deprecated classes.
- Adjusted `DirectoryNoModelRule` so it doesn't check deprecated classes.
- Adjusted `AllMethodIsPublicInFacadeRule` so it doesn't check deprecated methods.
- Adjusted `FacadeArgumentsNotAllowedUseEntityTransferRule` so it doesn't check deprecated methods.
- Adjusted `FacadeArgumentsRule` so it doesn't check deprecated methods.
- Adjusted `FacadeNoLogicRule` so it doesn't check deprecated methods.
- Adjusted `FacadeReturnValueRule` so it doesn't check deprecated methods.
- Adjusted `FacadeRule` so it doesn't check deprecated methods.
- Adjusted `FacadeSingleFactoryCallRule` so it doesn't check deprecated methods.
- Adjusted `PluginArgumentsNotAllowedUseEntityTransferRule` so it doesn't check deprecated classes.
- Adjusted `SpyEntityUsageRule` so it doesn't check deprecated methods.
