### PR TITLE
TE-10704 Fixed message about not supported return type and added message for absent param type

### DIFF
--- a/src/Common/Bridge/BridgeMethodsRule.php
+++ b/src/Common/Bridge/BridgeMethodsRule.php
@@ -154,7 +154,7 @@ class BridgeMethodsRule extends SprykerAbstractRule implements ClassAware
                     $this->addViolation(
                         $classMethod,
                         [sprintf(
-                            'Type hint should be defined for param `%s` in method `%s`.',
+                            'Type should be defined for param `%s` in method `%s`.',
                             $parameter->getName(),
                             $classMethod->getFullQualifiedName(),
                         )],

--- a/src/Common/Bridge/BridgeMethodsRule.php
+++ b/src/Common/Bridge/BridgeMethodsRule.php
@@ -42,13 +42,9 @@ class BridgeMethodsRule extends SprykerAbstractRule implements ClassAware
      */
     public function apply(AbstractNode $node)
     {
-        $pregMatch = preg_match('([A-Za-z0-9]+Bridge$)', $node->getName());
-
-        $pregMatch1 = preg_match('#.*\\\\Dependency(\\\\.*)?#', $node->getNamespaceName());
-
         if (
-            $pregMatch === 0 ||
-            $pregMatch1 === 0 ||
+            preg_match('([A-Za-z0-9]+Bridge$)', $node->getName()) === 0 ||
+            preg_match('#.*\\\\Dependency(\\\\.*)?#', $node->getNamespaceName()) === 0 ||
             !$node instanceof ClassNode
         ) {
             return;

--- a/src/Common/Bridge/BridgeMethodsRule.php
+++ b/src/Common/Bridge/BridgeMethodsRule.php
@@ -44,7 +44,7 @@ class BridgeMethodsRule extends SprykerAbstractRule implements ClassAware
     {
         if (
             preg_match('([A-Za-z0-9]+Bridge$)', $node->getName()) === 0 ||
-            preg_match('#.*\\\\Dependency(\\\\.*)?#', $node->getNamespaceName()) === 0 ||
+            preg_match('#.*\\\\Dependency\\\\.*#', $node->getNamespaceName()) === 0 ||
             !$node instanceof ClassNode
         ) {
             return;

--- a/src/Common/PhpDocTrait.php
+++ b/src/Common/PhpDocTrait.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace ArchitectureSniffer\Common;
+
+trait PhpDocTrait
+{
+    /**
+     * @param string|null $phpDoc
+     *
+     * @return string|null
+     */
+    protected function getReturnTypeByPhpDoc(?string $phpDoc): ?string
+    {
+        if ($phpDoc === null) {
+            return null;
+        }
+
+        $matches = [];
+
+        preg_match_all('/@return\s+([^\s]+)/', $phpDoc, $matches);
+
+        return $matches[1][0] ?? null;
+    }
+
+    /**
+     * @param string|null $phpDoc
+     *
+     * @return bool
+     */
+    protected function inheritDocTagExists(?string $phpDoc): bool
+    {
+        if ($phpDoc === null) {
+            return false;
+        }
+
+        return stripos($phpDoc, '@inheritDoc') !== false;
+    }
+
+    /**
+     * @param string|null $phpDoc
+     *
+     * @return bool
+     */
+    protected function apiTagExists(?string $phpDoc): bool
+    {
+        if ($phpDoc === null) {
+            return false;
+        }
+
+        return stripos($phpDoc, '@api') !== false;
+    }
+
+    /**
+     * @param string|null $phpDoc
+     * @param string $paramName
+     *
+     * @return string|null
+     */
+    protected function getParamTypeByPhpDoc(?string $phpDoc, string $paramName): ?string
+    {
+        if ($phpDoc === null) {
+            return null;
+        }
+
+        $matches = [];
+
+        preg_match_all(sprintf('/@param ([^\s]+) \$%s/', $paramName), $phpDoc, $matches);
+
+        return $matches[1][0] ?? null;
+    }
+}

--- a/src/Common/PhpTypesTrait.php
+++ b/src/Common/PhpTypesTrait.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace ArchitectureSniffer\Common;
+
+trait PhpTypesTrait
+{
+    /**
+     * @param string $type
+     *
+     * @return bool
+     */
+    protected function isTypeInPhp7NotAllowed(string $type): bool
+    {
+        $type = str_replace('|null', '', $type);
+
+        return strpos($type, '|') !== false
+            || $type === 'mixed'
+            || $type === 'false';
+    }
+}

--- a/tests/Common/Bridge/BridgeMethodsInterfaceTest.php
+++ b/tests/Common/Bridge/BridgeMethodsInterfaceTest.php
@@ -25,10 +25,30 @@ class BridgeMethodsInterfaceTest extends AbstractArchitectureSnifferRuleTest
     /**
      * @return void
      */
+    public function testRuleDoesNotApplyWhenReturnTypeIsNotSupportedInPhp7(): void
+    {
+        $bridgeMethodsInterfaceRule = new BridgeMethodsInterfaceRule();
+        $bridgeMethodsInterfaceRule->setReport($this->getReportMock(0));
+        $bridgeMethodsInterfaceRule->apply($this->getClassNode());
+    }
+
+    /**
+     * @return void
+     */
     public function testRuleAppliesWhenBridgeInterfaceMethodsAreNotCorrect(): void
     {
         $bridgeMethodsInterfaceRule = new BridgeMethodsInterfaceRule();
         $bridgeMethodsInterfaceRule->setReport($this->getReportMock(4));
+        $bridgeMethodsInterfaceRule->apply($this->getClassNode());
+    }
+
+    /**
+     * @return void
+     */
+    public function testRuleAppliesWhenReturnTypeIsAbsent(): void
+    {
+        $bridgeMethodsInterfaceRule = new BridgeMethodsInterfaceRule();
+        $bridgeMethodsInterfaceRule->setReport($this->getReportMock(2));
         $bridgeMethodsInterfaceRule->apply($this->getClassNode());
     }
 }

--- a/tests/Common/Bridge/BridgeMethodsTest.php
+++ b/tests/Common/Bridge/BridgeMethodsTest.php
@@ -31,4 +31,14 @@ class BridgeMethodsTest extends AbstractArchitectureSnifferRuleTest
         $bridgeMethodsRule->setReport($this->getReportMock(1));
         $bridgeMethodsRule->apply($this->getClassNode());
     }
+
+    /**
+     * @return void
+     */
+    public function testRuleAppliesWhenBridgeMethodsParamsShouldHaveTypeHint(): void
+    {
+        $bridgeMethodsRule = new BridgeMethodsRule();
+        $bridgeMethodsRule->setReport($this->getReportMock(1));
+        $bridgeMethodsRule->apply($this->getClassNode());
+    }
 }

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -8,5 +8,8 @@ require_once '_data/Common/Plugin/NewPluginExtensionModuleTest/testRuleDoesNotAp
 require_once '_data/Common/Plugin/NewPluginExtensionModuleTest/testRuleAppliesWhenPluginImplementsNotExtensionModuleInterface.php';
 require_once '_data/Common/Bridge/BridgeMethodsTest/testRuleAppliesWhenBridgeMethodsAreNotCorrect.php';
 require_once '_data/Common/Bridge/BridgeMethodsTest/testRuleDoesNotApplyWhenBridgeMethodsAreCorrect.php';
+require_once '_data/Common/Bridge/BridgeMethodsTest/testRuleAppliesWhenBridgeMethodsParamsShouldHaveTypeHint.php';
+require_once '_data/Common/Bridge/BridgeMethodsInterfaceTest/testRuleAppliesWhenReturnTypeIsAbsent.php';
+require_once '_data/Common/Bridge/BridgeMethodsInterfaceTest/testRuleDoesNotApplyWhenReturnTypeIsNotSupportedInPhp7.php';
 require_once '_data/Common/Bridge/BridgeMethodsInterfaceTest/testRuleAppliesWhenBridgeInterfaceMethodsAreNotCorrect.php';
 require_once '_data/Common/Bridge/BridgeMethodsInterfaceTest/testRuleDoesNotApplyWhenBridgeInterfaceMethodsAreCorrect.php';

--- a/tests/_data/Common/Bridge/BridgeMethodsInterfaceTest/testRuleAppliesWhenReturnTypeIsAbsent.php
+++ b/tests/_data/Common/Bridge/BridgeMethodsInterfaceTest/testRuleAppliesWhenReturnTypeIsAbsent.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace ArchitectureSnifferTest\Common\Bridge\Dependency\Client;
+
+class NotValidFooTooBarClientBridge implements NotValidFooTooBarClientInterface
+{
+    /**
+     * @param \ArchitectureSnifferTest\Common\Bridge\Zed\Bar\Client\BarClientInterface $barClient
+     */
+    public function __construct($barClient)
+    {
+    }
+    
+    /**
+     * @return string
+     */
+    public function getString()
+    {
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getStringOrNull()
+    {
+    }
+}
+
+interface NotValidFooTooBarClientInterface
+{
+    /**
+     * @return string
+     */
+    public function getString();
+
+    /**
+     * @return string|null
+     */
+    public function getStringOrNull();
+}
+
+namespace ArchitectureSnifferTest\Common\Bridge\Zed\Bar\Client;
+
+interface BarClientInterface
+{
+    /**
+     * @return string
+     */
+    public function getString();
+
+    /**
+     * @return string|null
+     */
+    public function getStringOrNull();
+}

--- a/tests/_data/Common/Bridge/BridgeMethodsInterfaceTest/testRuleDoesNotApplyWhenReturnTypeIsNotSupportedInPhp7.php
+++ b/tests/_data/Common/Bridge/BridgeMethodsInterfaceTest/testRuleDoesNotApplyWhenReturnTypeIsNotSupportedInPhp7.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace ArchitectureSnifferTest\Common\Bridge\Dependency\Client;
+
+use ArchitectureSnifferTest\Common\Bridge\DataLayer\DataObject;
+use ArchitectureSnifferTest\Common\Bridge\DataLayer\ReturnDataObject;
+
+class ValidFooTooBarClientBridge implements ValidFooTooBarClientInterface
+{
+    /**
+     * @param \ArchitectureSnifferTest\Common\Bridge\Yves\Bar\Client\BarClientInterface $barClient
+     */
+    public function __construct($barClient)
+    {
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getMixed()
+    {
+    }
+
+    /**
+     * @return false
+     */
+    public function getFalse()
+    {
+    }
+
+    /**
+     * @return int|float
+     */
+    public function getIntOrFloat()
+    {
+    }
+}
+
+interface ValidFooTooBarClientInterface
+{
+    /**
+     * @return mixed
+     */
+    public function getMixed();
+
+    /**
+     * @return false
+     */
+    public function getFalse();
+
+    /**
+     * @return int|float
+     */
+    public function getIntOrFloat();
+}
+
+namespace ArchitectureSnifferTest\Common\Bridge\Yves\Bar\Client;
+
+interface BarClientInterface
+{
+    /**
+     * @return mixed
+     */
+    public function getMixed();
+
+    /**
+     * @return false
+     */
+    public function getFalse();
+
+    /**
+     * @return int|float
+     */
+    public function getIntOrFloat();
+}

--- a/tests/_data/Common/Bridge/BridgeMethodsTest/testRuleAppliesWhenBridgeMethodsParamsShouldHaveTypeHint.php
+++ b/tests/_data/Common/Bridge/BridgeMethodsTest/testRuleAppliesWhenBridgeMethodsParamsShouldHaveTypeHint.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace ArchitectureSnifferTest\Common\Bridge\Dependency\Client;
+
+class MustBeStricterFooTooBarClientBridge implements MustBeStricterFooTooBarClientInterface
+{
+    /**
+     * @param \ArchitectureSnifferTest\Common\Bridge\Zed\Bar\Client\BarClientInterface $barClient
+     */
+    public function __construct($barClient)
+    {
+    }
+
+    /**
+     * @param string|null $key
+     *
+     * @return string
+     */
+    public function getByString($key): string
+    {
+    }
+
+    /**
+     * @param mixed $key
+     *
+     * @return string
+     */
+    public function getByMixed($key): string
+    {
+    }
+
+    /**
+     * @param int|float $key
+     *
+     * @return string
+     */
+    public function getByIntOrFloat($key): string
+    {
+    }
+}
+
+interface MustBeStricterFooTooBarClientInterface
+{
+    /**
+     * @param string|null $key
+     *
+     * @return string
+     */
+    public function getByString($key): string;
+
+    /**
+     * @param mixed $key
+     *
+     * @return string
+     */
+    public function getByMixed($key): string;
+
+    /**
+     * @param int|float $key
+     *
+     * @return string
+     */
+    public function getByIntOrFloat($key): string;
+}
+
+namespace ArchitectureSnifferTest\Common\Bridge\Zed\Bar\Client;
+
+interface MustBeStricterBarClientInterface
+{
+    /**
+     * @param string|null $key
+     *
+     * @return string
+     */
+    public function getByString($key): string;
+
+    /**
+     * @param mixed $key
+     *
+     * @return string
+     */
+    public function getByMixed($key): string;
+
+    /**
+     * @param int|float $key
+     *
+     * @return string
+     */
+    public function getByIntOrFloat($key): string;
+}


### PR DESCRIPTION
- Developer(s): @dmytro-dymarchuk 

- Ticket: https://spryker.atlassian.net/browse/TE-10704

- Release Group: https://release.spryker.com/release-groups/view/3968

- merge: merge

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   ArchitectureSniffer   | patch (currently 0.x)  |                       |

-----------------------------------------

#### Module ArchitectureSniffer

##### Change log

### Fixes

- Adjusted `BridgeMethodsInterfaceRule` so it skips the 'Missed return type' error if the return type is not supported in PHP7.

### Improvements

- Adjusted `BridgeMethodsRule` so it raises an error if the type of method params should be set.