### PR TITLE
TE-11044 Fixed `$this` as required for return type

### DIFF
--- a/src/Common/Method/ExternalMethodExtensionReturnTypeRule.php
+++ b/src/Common/Method/ExternalMethodExtensionReturnTypeRule.php
@@ -69,7 +69,7 @@ class ExternalMethodExtensionReturnTypeRule extends AbstractRule implements Clas
             if (
                 $returnType == null
                 || $this->isTypeInPhp7NotAllowed($returnType)
-                || $this->isReturnTypeIsThis($returnType)
+                || $this->isFluentInterface($returnType)
             ) {
                 continue;
             }

--- a/src/Common/Method/ExternalMethodExtensionReturnTypeRule.php
+++ b/src/Common/Method/ExternalMethodExtensionReturnTypeRule.php
@@ -69,6 +69,7 @@ class ExternalMethodExtensionReturnTypeRule extends AbstractRule implements Clas
             if (
                 $returnType == null
                 || $this->isTypeInPhp7NotAllowed($returnType)
+                || $this->isReturnTypeIsThis($returnType)
             ) {
                 continue;
             }

--- a/src/Common/PhpTypesTrait.php
+++ b/src/Common/PhpTypesTrait.php
@@ -39,9 +39,9 @@ trait PhpTypesTrait
      *
      * @return bool
      */
-    protected function isReturnTypeIsThis(string $type): bool
+    protected function isFluentInterface(string $type): bool
     {
-        $type = $type = $this->stripNullReturnTypeHint($type);
+        $type = $this->stripNullReturnTypeHint($type);
 
         return strpos($type, '|') !== false
             || $type === '$this';

--- a/src/Common/PhpTypesTrait.php
+++ b/src/Common/PhpTypesTrait.php
@@ -12,15 +12,38 @@ trait PhpTypesTrait
     /**
      * @param string $type
      *
+     * @return string
+     */
+    protected function stripNullReturnTypeHint(string $type): string
+    {
+        return str_replace('|null', '', $type);
+    }
+
+    /**
+     * @param string $type
+     *
      * @return bool
      */
     protected function isTypeInPhp7NotAllowed(string $type): bool
     {
-        $type = str_replace('|null', '', $type);
+        $type = $this->stripNullReturnTypeHint($type);
 
         return strpos($type, '|') !== false
             || $type === 'mixed'
             || $type === 'false'
             || $type === 'static';
+    }
+
+    /**
+     * @param string $type
+     *
+     * @return bool
+     */
+    protected function isReturnTypeIsThis(string $type): bool
+    {
+        $type = $type = $this->stripNullReturnTypeHint($type);
+
+        return strpos($type, '|') !== false
+            || $type === '$this';
     }
 }

--- a/src/PropelQuery/Schema/PropelSchemaTableFinder.php
+++ b/src/PropelQuery/Schema/PropelSchemaTableFinder.php
@@ -337,7 +337,7 @@ class PropelSchemaTableFinder implements PropelSchemaTableFinderInterface
      * @param \ArchitectureSniffer\PropelQuery\Schema\Transfer\PropelSchemaTableTransfer $tableTransfer
      * @param \ArchitectureSniffer\Path\Transfer\PathTransfer $pathTransfer
      *
-     * @return \Countable|array<\Symfony\Component\Finder\SplFileInfo>
+     * @return \Countable<\Symfony\Component\Finder\SplFileInfo>
      */
     protected function findSchemaFiles(PropelSchemaTableTransfer $tableTransfer, PathTransfer $pathTransfer): Countable
     {

--- a/src/PropelQuery/Schema/PropelSchemaTableFinder.php
+++ b/src/PropelQuery/Schema/PropelSchemaTableFinder.php
@@ -337,7 +337,7 @@ class PropelSchemaTableFinder implements PropelSchemaTableFinderInterface
      * @param \ArchitectureSniffer\PropelQuery\Schema\Transfer\PropelSchemaTableTransfer $tableTransfer
      * @param \ArchitectureSniffer\Path\Transfer\PathTransfer $pathTransfer
      *
-     * @return \Symfony\Component\Finder\SplFileInfo[]|\Countable
+     * @return \Countable|array<\Symfony\Component\Finder\SplFileInfo>
      */
     protected function findSchemaFiles(PropelSchemaTableTransfer $tableTransfer, PathTransfer $pathTransfer): Countable
     {

--- a/src/Zed/Business/Facade/FacadeInterfaceRule.php
+++ b/src/Zed/Business/Facade/FacadeInterfaceRule.php
@@ -77,7 +77,7 @@ class FacadeInterfaceRule extends AbstractFacadeRule implements ClassAware
 
     /**
      * @param \PHPMD\Node\ClassNode $node
-     * @param \PDepend\Source\AST\ASTArtifactList|array<\PDepend\Source\AST\ASTInterface> $implementedInterfaces
+     * @param \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTInterface> $implementedInterfaces
      *
      * @return bool
      */

--- a/src/Zed/Business/Facade/FacadeInterfaceRule.php
+++ b/src/Zed/Business/Facade/FacadeInterfaceRule.php
@@ -77,7 +77,7 @@ class FacadeInterfaceRule extends AbstractFacadeRule implements ClassAware
 
     /**
      * @param \PHPMD\Node\ClassNode $node
-     * @param \PDepend\Source\AST\ASTArtifactList|\PDepend\Source\AST\ASTInterface[] $implementedInterfaces
+     * @param \PDepend\Source\AST\ASTArtifactList|array<\PDepend\Source\AST\ASTInterface> $implementedInterfaces
      *
      * @return bool
      */


### PR DESCRIPTION
- Developer(s): @yaroslav-spryker 

- Ticket: https://spryker.atlassian.net/browse/TE-11044

- merge: squash

#### Release Table

 Module                | Release Type         | Constraint Updates         |
 :--------------------- | :------------------------ | :--------------------- |
   ArchitectureSniffer     | patch                 |                |
-----------------------------------------

#### Module ArchitectureSniffer

##### Change log

Improvements

- Fixed `ExternalMethodExtensionReturnTypeRule` by not forcing `$this` to have required a return type.
