### PR TITLE
Allow list as facade return type

### DIFF
--- a/src/Zed/Business/Facade/FacadeReturnValueRule.php
+++ b/src/Zed/Business/Facade/FacadeReturnValueRule.php
@@ -32,7 +32,7 @@ class FacadeReturnValueRule extends AbstractFacadeRule implements MethodAware
     /**
      * @var string
      */
-    protected const ALLOWED_RETURN_TYPES_PATTERN = '/@return\s(?!void|int|integer|bool|boolean|float|string|array|\[\]|.*\[\]|((.+)Transfer))(.*)/';
+    protected const ALLOWED_RETURN_TYPES_PATTERN = '/@return\s(?!void|int|integer|bool|boolean|float|string|list|array|\[\]|.*\[\]|((.+)Transfer))(.*)/';
 
     /**
      * @var int


### PR DESCRIPTION
## 📚 Description

Modern PHPDoc syntax allows you to differentiate between `list` and `array`

This should be valid:

<img width="1494" alt="Screenshot 2023-02-03 at 16 39 01" src="https://user-images.githubusercontent.com/5256287/216644376-de14a587-39ba-4662-b17e-f19af8dfefd1.png">


### Examples

- `list<int>`: a sorted list with only INT values – [1, 4, 6, 8, 9, …]
- `list<Order>`: a list with only „Order“-Object values – [Order, Order, …]
- `array<int, int>`: an array with INT keys and INT values – [4 => 1, 8 => 4, 12 => 6, …]
- `array<int, string>`: an array with INT keys and STRING values – [4 => „foo“, 8 => „bar“, …]
- `array{age: int, name: string}`: an array with key `age' holding an int, and key 'name' holding a string

### References

- https://suckup.de/2020/02/modern-phpdoc-annotations/
- https://phpstan.org/writing-php-code/phpdoc-types#lists

