### PR TITLE
Fixed issue PHP Fatal error: Call to a member function getImage() on bool in ModuleConstantsFormingConstantValuesRule.php:47

### DIFF
--- a/src/Shared/ModuleConstantsFormingConstantValuesRule.php
+++ b/src/Shared/ModuleConstantsFormingConstantValuesRule.php
@@ -7,6 +7,7 @@
 
 namespace ArchitectureSniffer\Shared;
 
+use PDepend\Source\AST\ASTNode;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\InterfaceAware;
@@ -44,7 +45,9 @@ class ModuleConstantsFormingConstantValuesRule extends AbstractRule implements I
 
         foreach ($node->findChildrenOfType('ConstantDeclarator') as $constant) {
             /** @var \PDepend\Source\AST\ASTValue|\PHPMD\AbstractNode $constant */
-            $value = $constant->getValue()->getValue()->getImage();
+            $constantValue = $constant->getValue()->getValue();
+
+            $value = $constantValue instanceof ASTNode ? $constantValue->getImage() : $constantValue;
 
             $expectedConstantValue = sprintf(
                 "'%s:%s'",


### PR DESCRIPTION

## PR Description
- fixes issue with scanning Shared constant files that contain boolean or integers values

## Resolves:
https://github.com/spryker/architecture-sniffer/issues/124
https://spryker.atlassian.net/browse/SDK-5710

TBD

## Checklist
- [ ] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
